### PR TITLE
make iframe stretch within constraints

### DIFF
--- a/libs/we-elements/src/elements/wal-embed.ts
+++ b/libs/we-elements/src/elements/wal-embed.ts
@@ -148,7 +148,7 @@ export class WalEmbed extends LitElement {
           frameborder="0"
           title="TODO"
           src="${iframeSrc}"
-          style="flex: 1; display: block; padding: 5px; margin: 0; resize: both;"
+          style="flex: 1; display: block; padding: 5px; margin: 0; resize: both; width: calc(100% - 10px); height: 100vh;"
           allow="clipboard-write;"
           @load=${() => {
             console.log('iframe loaded.');


### PR DESCRIPTION
Added the following css to the embed iframe
- width: calc(100% - 10px);
- height: 100vh;

This seems to fix the embed size issues when applied from dev tools, although I did not test the changes from a fresh build.