### PR TITLE
on-before-unload event

### DIFF
--- a/example/ui/src/applet-main.ts
+++ b/example/ui/src/applet-main.ts
@@ -83,15 +83,9 @@ export class AppletMain extends LitElement {
   failUnbeforeUnloadCheckmark!: HTMLInputElement;
 
   onBeforeUnloadUnsubscribe: UnsubscribeFunction | undefined;
-  onBeforeUnloadUnsubscribe2: UnsubscribeFunction | undefined;
 
   async firstUpdated() {
-    this.onBeforeUnloadUnsubscribe = this.weaveClient.onBeforeUnload(async () => {
-      console.log('Unloading in 20 seconds');
-      await new Promise((resolve) => setTimeout(resolve, 20000));
-      console.log('Unloading now.');
-    });
-    this.onBeforeUnloadUnsubscribe2 = this.weaveClient.onBeforeUnload(() => {
+    this.onBeforeUnloadUnsubscribe = this.weaveClient.onBeforeUnload(() => {
       if (this.failUnbeforeUnloadCheckmark.checked)
         throw new Error(
           'The onbeforeunload callback failed (intentionally for testing purposes) in the example applet :(.'
@@ -105,7 +99,6 @@ export class AppletMain extends LitElement {
 
   disconnectedCallback(): void {
     if (this.onBeforeUnloadUnsubscribe) this.onBeforeUnloadUnsubscribe();
-    if (this.onBeforeUnloadUnsubscribe2) this.onBeforeUnloadUnsubscribe2();
   }
 
   // disconnectedCallback(): void {

--- a/example/ui/src/elements/post-detail.ts
+++ b/example/ui/src/elements/post-detail.ts
@@ -28,7 +28,7 @@ import './edit-post.js';
 import { PostsStore } from '../posts-store.js';
 import { postsStoreContext } from '../context.js';
 import { Post } from '../types.js';
-import { WAL, weaveUrlFromWal } from '@theweave/api';
+import { WAL, WeaveClient, weaveUrlFromWal } from '@theweave/api';
 
 /**
  * @element post-detail
@@ -40,6 +40,9 @@ export class PostDetail extends LitElement {
   // REQUIRED. The hash of the Post to show
   @property(hashProperty('post-hash'))
   postHash!: ActionHash;
+
+  @property()
+  weaveClient!: WeaveClient;
 
   /**
    * @internal
@@ -126,6 +129,12 @@ export class PostDetail extends LitElement {
         </sl-card>
         <attachments-card .wal=${weaveUrlFromWal(this.WAL!, false)}></attachments-card>
       </div>
+      <sl-button
+        style="margin-top: 20px;"
+        variant="danger"
+        @click=${() => this.weaveClient.requestClose()}
+        >Close Window (only works if open in separate Window)</sl-button
+      >
     `;
   }
 

--- a/example/ui/src/example-applet.ts
+++ b/example/ui/src/example-applet.ts
@@ -124,6 +124,7 @@ export class ExampleApplet extends LitElement {
                               <attachments-context .store=${this.attachmentsStore}>
                                 <post-detail
                                   .postHash=${this.weaveClient.renderInfo.view.wal.hrl[1]}
+                                  .weaveClient=${this.weaveClient}
                                 ></post-detail>
                               </attachments-context>
                             </posts-context>

--- a/example/ui/src/example-applet.ts
+++ b/example/ui/src/example-applet.ts
@@ -42,7 +42,14 @@ export class ExampleApplet extends LitElement {
 
   peerStatusUnsubscribe: UnsubscribeFunction | undefined;
 
+  onBeforeUnloadUnsubscribe: UnsubscribeFunction | undefined;
+
   firstUpdated() {
+    this.onBeforeUnloadUnsubscribe = this.weaveClient.onBeforeUnload(async () => {
+      console.log('Unloading in 10 seconds');
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+      console.log('Unloading now.');
+    });
     // To test whether applet iframe properly gets removed after disabling applet.
     // setInterval(() => {
     //   console.log('Hello from the example applet iframe.');

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -40,6 +40,11 @@ import {
 import { readable } from '@holochain-open-dev/stores';
 import { toOriginalCaseB64 } from '@theweave/utils';
 
+type CallbackWithId = {
+  id: number;
+  callback: () => any;
+};
+
 declare global {
   interface Window {
     __WEAVE_API__: WeaveServices;
@@ -49,6 +54,7 @@ declare global {
     __WEAVE_APPLET_ID__: AppletId;
     __WEAVE_PROTOCOL_VERSION__: string;
     __MOSS_VERSION__: string;
+    __WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__: Array<CallbackWithId> | undefined;
   }
 
   interface WindowEventMap {
@@ -60,11 +66,40 @@ const weaveApi: WeaveServices = {
   mossVersion: () => {
     return window.__MOSS_VERSION__;
   },
+
   onPeerStatusUpdate: (callback: (payload: PeerStatusUpdate) => any) => {
     const listener = (e: CustomEvent<PeerStatusUpdate>) => callback(e.detail);
     window.addEventListener('peer-status-update', listener);
     return () => window.removeEventListener('peer-status-update', listener);
   },
+
+  onBeforeUnload: (callback: () => void) => {
+    // registers a callback on the window object that will be called before
+    // the iframe gets unloaded
+    const existingCallbacks = window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ || [];
+    let newCallbackId = 0;
+    const existingCallbackIds = existingCallbacks.map((callbackWithId) => callbackWithId.id);
+    if (existingCallbackIds && existingCallbackIds.length > 0) {
+      // every new callback gets a new id in increasing manner
+      const highestId = existingCallbackIds.sort((a, b) => b - a)[0];
+      newCallbackId = highestId + 1;
+    }
+
+    existingCallbacks.push({ id: newCallbackId, callback });
+
+    window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ = existingCallbacks;
+
+    const unlisten = () => {
+      const allCallbacks = window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ || [];
+      window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ = allCallbacks.filter(
+        (callbackWithId) => callbackWithId.id !== newCallbackId,
+      );
+    };
+
+    // We return an unlistener function which removes the callback from the list of callbacks
+    return unlisten;
+  },
+
   openAppletMain: async (appletHash: EntryHash): Promise<void> =>
     postMessage({
       type: 'open-view',
@@ -233,7 +268,7 @@ const weaveApi: WeaveServices = {
 
     const appletHash = window.__WEAVE_APPLET_HASH__;
 
-    // message handler for ParentToApplet messages - Only added for applet main-view
+    // message handler for ParentToApplet messages
     window.addEventListener('message', async (m: MessageEvent<any>) => {
       try {
         const result = await handleMessage(appletClient, appletHash, m.data);
@@ -290,6 +325,17 @@ const weaveApi: WeaveServices = {
       ),
     );
 
+    // message handler for ParentToApplet messages - Only events are handled in the cross-group view
+    window.addEventListener('message', async (m: MessageEvent<any>) => {
+      try {
+        const result = await handleEventMessage(m.data);
+        m.ports[0].postMessage({ type: 'success', result });
+      } catch (e) {
+        console.error('Failed to send postMessage to cross-group-view', e);
+        m.ports[0]?.postMessage({ type: 'error', error: (e as any).message });
+      }
+    });
+
     window.__WEAVE_RENDER_INFO__ = {
       type: 'cross-applet-view',
       view: view.view,
@@ -329,6 +375,20 @@ async function fetchLocalStorage() {
   );
 }
 
+const handleEventMessage = async (message: ParentToAppletMessage) => {
+  switch (message.type) {
+    case 'on-before-unload':
+      console.log('@applet-iframe: got on-before-unload event in cross-group-view');
+      const allCallbacks = window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ || [];
+      await Promise.all(
+        allCallbacks.map(async (callbackWithId) => await callbackWithId.callback()),
+      );
+      return;
+    default:
+      return;
+  }
+};
+
 const handleMessage = async (
   appletClient: AppClient,
   appletHash: AppletHash,
@@ -364,6 +424,15 @@ const handleMessage = async (
         }),
       );
       break;
+    case 'on-before-unload': {
+      // Call all registered callbacks
+      console.log('@applet-iframe: got on-before-unload event');
+      const allCallbacks = window.__WEAVE_ON_BEFORE_UNLOAD_CALLBACKS__ || [];
+      await Promise.all(
+        allCallbacks.map(async (callbackWithId) => await callbackWithId.callback()),
+      );
+      return;
+    }
     default:
       throw new Error(
         `Unknown ParentToAppletMessage type: '${(message as any).type}'. Message: ${message}`,

--- a/libs/api/src/api.ts
+++ b/libs/api/src/api.ts
@@ -226,6 +226,18 @@ export interface WeaveServices {
    */
   onPeerStatusUpdate: (callback: (payload: PeerStatusUpdate) => any) => UnsubscribeFunction;
   /**
+   * Event listener allowing to register a callback that will get executed before the
+   * applet gets reloaded, for example to save intermediate user input (e.g. commit
+   * the most recent changes of a document to the source chain).
+   *
+   * If this callback takes too long, users may be offered to force reload, thereby
+   * ignoring/cancelling the pending callback.
+   *
+   * @param callback Callback that gets called before the Applet gets reloaded
+   * @returns
+   */
+  onBeforeUnload: (callback: () => void) => UnsubscribeFunction;
+  /**
    * Open the main view of the specified Applet
    * @param appletHash
    * @returns
@@ -367,6 +379,10 @@ export class WeaveClient implements WeaveServices {
 
   onPeerStatusUpdate = (callback: (payload: PeerStatusUpdate) => any): UnsubscribeFunction => {
     return window.__WEAVE_API__.onPeerStatusUpdate(callback);
+  };
+
+  onBeforeUnload = (callback: () => any): UnsubscribeFunction => {
+    return window.__WEAVE_API__.onBeforeUnload(callback);
   };
 
   openAppletMain = async (appletHash: EntryHash): Promise<void> =>

--- a/libs/api/src/types.ts
+++ b/libs/api/src/types.ts
@@ -293,6 +293,9 @@ export type ParentToAppletMessage =
   | {
       type: 'peer-status-update';
       payload: PeerStatusUpdate;
+    }
+  | {
+      type: 'on-before-unload';
     };
 
 export type AppletToParentMessage = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.lightningrodlabs.moss-0.13",
-  "version": "0.13.0-gamma.2",
+  "version": "0.13.0-gamma.3",
   "private": true,
   "description": "Moss (0.13)",
   "main": "./out/main/index.js",
@@ -22,6 +22,7 @@
     "applet-dev": "yarn check:binaries && concurrently  \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 1\" \"sleep 10 && electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 2 --sync-time 10000\"",
     "applet-dev-1": "yarn check:binaries && concurrently \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"yarn workspace @theweave/attachments build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 1\"",
     "applet-dev-3": "yarn check:binaries && concurrently  \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 1\" \"sleep 5 && electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 2 --sync-time 10000\" \"sleep 5 && electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 3 --sync-time 10000\"",
+    "applet-dev-example-1": "yarn check:binaries && concurrently  \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.example.ts --agent-idx 1\"",
     "applet-dev-example": "yarn check:binaries && concurrently  \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.example.ts --agent-idx 1\" \"sleep 10 && electron-vite dev -- --dev-config weave.dev.config.example.ts --agent-idx 2\"",
     "dev": "yarn check:binaries && concurrently  \"yarn workspace @theweave/api build:watch\" \"yarn workspace @theweave/elements build:watch\" \"UI_PORT=8888 yarn workspace example-applet start\" \"electron-vite dev -- --dev-config weave.dev.config.ts --agent-idx 1\"",
     "dev:electron": "electron-vite dev",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -290,18 +290,8 @@ setupLogs(WE_EMITTER, WE_FILE_SYSTEM, RUN_OPTIONS.printHolochainLogs);
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'moss',
-    privileges: { standard: true, supportFetchAPI: true, secure: true, stream: true },
+    privileges: { standard: true, secure: true, stream: true, supportFetchAPI: true },
   },
-]);
-
-protocol.registerSchemesAsPrivileged([
-  {
-    scheme: 'default-app',
-    privileges: { standard: true, supportFetchAPI: true, secure: true, stream: true },
-  },
-]);
-
-protocol.registerSchemesAsPrivileged([
   {
     scheme: 'applet',
     privileges: { standard: true, supportFetchAPI: true, secure: true, stream: true },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -887,8 +887,15 @@ app.whenReady().then(async () => {
       return;
     }
     const newWalWindow = createWalWindow();
+    // on-before-unload (added here for searchability of event-related code)
+    // This event is forwarded to the window in order to discern in the
+    // onbeforeunload callback between reloading and closing of the window
     newWalWindow.on('close', () => {
-      delete WAL_WINDOWS[src];
+      // on-before-unload
+      // closing may be prevented by the beforeunload event listener in the window
+      // the first time. The window should however be hidden already anyway.
+      newWalWindow.hide();
+      emitToWindow(newWalWindow, 'window-closing', null);
     });
     WAL_WINDOWS[src] = {
       window: newWalWindow,

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -41,6 +41,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('deep-link-received', callback),
   onSwitchToApplet: (callback: (e: Electron.IpcRendererEvent, payload: AppletId) => any) =>
     ipcRenderer.on('switch-to-applet', callback),
+  onWindowClosing: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('window-closing', callback),
   onZomeCallSigned: (
     callback: (
       e: Electron.IpcRendererEvent,
@@ -51,6 +53,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       },
     ) => any,
   ) => ipcRenderer.on('zome-call-signed', callback),
+  closeMainWindow: () => ipcRenderer.invoke('close-main-window'),
   openApp: (appId: string) => ipcRenderer.invoke('open-app', appId),
   openAppStore: () => ipcRenderer.invoke('open-appstore'),
   openWalWindow: (iframeSrc: string, appletId: AppletId, wal: WAL) =>
@@ -141,6 +144,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ),
   uninstallApplet: (appId: string) => ipcRenderer.invoke('uninstall-applet', appId),
   dumpNetworkStats: () => ipcRenderer.invoke('dump-network-stats'),
+  fetchAndValidateHappOrWebhapp: (url: string) =>
+    ipcRenderer.invoke('fetch-and-validate-happ-or-webhapp', url),
   validateHappOrWebhapp: (bytes: number[]) => ipcRenderer.invoke('validate-happ-or-webhapp', bytes),
 });
 

--- a/src/preload/walwindow.ts
+++ b/src/preload/walwindow.ts
@@ -12,6 +12,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   focusMainWindow: () => ipcRenderer.invoke('focus-main-window'),
   focusMyWindow: () => ipcRenderer.invoke('focus-my-window'),
   getMySrc: () => ipcRenderer.invoke('get-my-src'),
+  onWindowClosing: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('window-closing', callback),
   selectScreenOrWindow: () => ipcRenderer.invoke('select-screen-or-window'),
   setMyIcon: (icon: string) => ipcRenderer.invoke('set-my-icon', icon),
   setMyTitle: (title: string) => ipcRenderer.invoke('set-my-title', title),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -64,6 +64,15 @@
     <script>
       window['__HC_LAUNCHER_ENV__'] = {};
     </script>
+    <!-- code to make on-before-unload working: -->
+    <script>
+      window.electronAPI.onWindowClosing(() => {
+        // This code is required to discern in the window.onbeforeunload callback
+        // whether the onbeforunload event is coming from a page reload or from a
+        // page close
+        window.__WINDOW_CLOSING__ = true;
+      });
+    </script>
     <script type="module">
       import '@shoelace-style/shoelace/dist/themes/light.css';
       import '@fontsource/aileron';

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -137,6 +137,9 @@ export function buildHeadlessWeaveClient(mossStore: MossStore): WeaveServices {
     onPeerStatusUpdate(_) {
       return () => undefined;
     },
+    onBeforeUnload(_) {
+      return () => undefined;
+    },
     async assetInfo(wal: WAL): Promise<AssetLocationAndInfo | undefined> {
       const maybeCachedInfo = mossStore.weCache.assetInfo.value(wal);
       if (maybeCachedInfo) return maybeCachedInfo;

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -45,6 +45,7 @@ declare global {
           },
         ) => any,
       ) => any;
+      closeMainWindow: () => Promise<void>;
       openApp: (appId: string) => Promise<void>;
       openWalWindow: (iframeSrc: string, appletId: AppletId, wal: WAL) => Promise<void>;
       getAllAppAssetsInfos: () => Promise<
@@ -101,6 +102,7 @@ declare global {
       ) => Promise<void>;
       uninstallApplet: (appId: string) => Promise<void>;
       dumpNetworkStats: () => Promise<void>;
+      fetchAndValidateHappOrWebhapp: (url: string) => Promise<AppHashes>;
       validateHappOrWebhapp: (bytes: number[]) => Promise<AppHashes>;
     };
     __ZOME_CALL_LOGGING_ENABLED__: boolean;
@@ -189,6 +191,10 @@ export async function disableDevMode(): Promise<void> {
 
 export async function selectScreenOrWindow(): Promise<string> {
   return window.electronAPI.selectScreenOrWindow();
+}
+
+export async function fetchAndValidateHappOrWebhapp(url: string) {
+  return window.electronAPI.fetchAndValidateHappOrWebhapp(url);
 }
 
 export async function validateHappOrWebhapp(bytes: number[]) {

--- a/src/renderer/src/layout/views/applet-main.ts
+++ b/src/renderer/src/layout/views/applet-main.ts
@@ -12,10 +12,14 @@ export class AppletMain extends LitElement {
   @property(hashProperty('applet-hash'))
   appletHash!: EntryHash;
 
+  @property()
+  reloading = false;
+
   render() {
     return html`<applet-view
       .view=${{ type: 'main' }}
       .appletHash=${this.appletHash}
+      .reloading=${this.reloading}
       .hostColor=${'#588121'}
       style="flex: 1"
     ></applet-view>`;

--- a/src/renderer/src/layout/views/applet-view.ts
+++ b/src/renderer/src/layout/views/applet-view.ts
@@ -22,9 +22,8 @@ export class AppletViewEl extends LitElement {
   @property()
   hostColor: string | undefined;
 
-  firstUpdated() {
-    this.shadowRoot!.host.classList.add();
-  }
+  @property()
+  reloading = false;
 
   hostStyle() {
     if (this.hostColor) {
@@ -49,6 +48,7 @@ export class AppletViewEl extends LitElement {
       <view-frame
         .renderView=${renderView}
         .appletHash=${this.appletHash}
+        .reloading=${this.reloading}
         class="elevated"
         style="flex: 1; overflow: hidden;"
       ></view-frame>

--- a/src/renderer/src/layout/views/view-frame.ts
+++ b/src/renderer/src/layout/views/view-frame.ts
@@ -57,7 +57,7 @@ export class ViewFrame extends LitElement {
           if (this.reloading) {
             this.slowLoading = true;
           }
-        }, 5000);
+        }, 4500);
         this.loading = true;
       } else {
         if (this.slowReloadTimeout) window.clearTimeout(this.slowReloadTimeout);

--- a/src/renderer/src/layout/views/view-frame.ts
+++ b/src/renderer/src/layout/views/view-frame.ts
@@ -11,6 +11,8 @@ import { mossStoreContext } from '../../context.js';
 import { MossStore } from '../../moss-store.js';
 import { localized, msg } from '@lit/localize';
 
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+
 @localized()
 @customElement('view-frame')
 export class ViewFrame extends LitElement {

--- a/src/renderer/src/personal-views/tool-publishing/elements/publish-tool.ts
+++ b/src/renderer/src/personal-views/tool-publishing/elements/publish-tool.ts
@@ -17,7 +17,7 @@ import { consume } from '@lit/context';
 import { ActionHash } from '@holochain/client';
 import { resizeAndExport } from '../../../utils.js';
 import { AppHashes, WebHappSource } from '@theweave/moss-types';
-import { validateHappOrWebhapp } from '../../../electron-api.js';
+import { fetchAndValidateHappOrWebhapp } from '../../../electron-api.js';
 import { Tool } from '@theweave/tool-library-client';
 
 @localized()
@@ -79,32 +79,22 @@ export class PublishTool extends LitElement {
     version: string;
     webhapp_url: string;
   }) {
-    this._publishing = 'Fetching resource for validation...';
     console.log('TRYING TO PUBLISH TOOL...');
     if (!this._toolIconSrc) {
       this._publishing = undefined;
       notifyError('No Icon provided.');
       throw new Error('Icon is required.');
     }
-    // try to fetch (web)happ from source to verify link
-    let byteArray: number[];
-    try {
-      const response = await fetch(fields.webhapp_url);
-      byteArray = Array.from(new Uint8Array(await response.arrayBuffer()));
-    } catch (e) {
-      this._publishing = undefined;
-      notifyError('Failed to fetch resource at the specified URL');
-      throw new Error(`Failed to fetch resource at the specified URL: ${e}`);
-    }
+
     // verify that resource is of the right format (happ or webhapp) and compute the hashes
     let hashes: AppHashes;
     try {
-      this._publishing = 'Validating resource format and computing hashes...';
-      hashes = await validateHappOrWebhapp(byteArray);
+      this._publishing = 'Fetching and validating resource and computing hashes...';
+      hashes = await fetchAndValidateHappOrWebhapp(fields.webhapp_url);
     } catch (e) {
       this._publishing = undefined;
       notifyError(
-        `Asset format validation failed. Make sure the URL points to a valid .webhapp or .happ file.`,
+        `Asset format validation failed. Make sure the URL is valid and points to a valid .webhapp or .happ file.`,
       );
       throw new Error(`Asset format validation failed: ${e}`);
     }

--- a/src/renderer/src/utils.ts
+++ b/src/renderer/src/utils.ts
@@ -887,7 +887,6 @@ export async function postMessageToAppletIframes(
   if (appletIds.type === 'some') {
     const relevantSrcs = appletIds.ids.map((id) => appletOriginFromAppletId(id));
     allAppletIframes = allAppletIframes.filter((iframe) => {
-      console.log('IFRAME SRC: ', iframe.src);
       let matches = false;
       if (extraOrigins) {
         extraOrigins.forEach((origin) => {
@@ -911,9 +910,7 @@ export async function postMessageToAppletIframes(
 
   return Promise.allSettled(
     allAppletIframes.map(async (iframe) => {
-      console.log('seinding msg');
       await postMessageToIframe(iframe, message);
-      console.log('msg done.');
     }),
   );
 }

--- a/src/renderer/src/utils.ts
+++ b/src/renderer/src/utils.ts
@@ -21,7 +21,15 @@ import {
   DnaModifiers,
   InstalledAppId,
 } from '@holochain/client';
-import { Hrl, WAL, RenderView, FrameNotification, AppletHash, AppletId } from '@theweave/api';
+import {
+  Hrl,
+  WAL,
+  RenderView,
+  FrameNotification,
+  AppletHash,
+  AppletId,
+  ParentToAppletMessage,
+} from '@theweave/api';
 import { GroupDnaProperties } from '@theweave/group-client';
 import { decode, encode } from '@msgpack/msgpack';
 import { Base64, fromUint8Array, toUint8Array } from 'js-base64';
@@ -855,4 +863,78 @@ export function localTimeFromUtcOffset(offsetMinues: number): string {
 
   // Format the time in HH:MM format
   return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Posts a message to all iframes of the specified AppletIds and returns the settled promises.
+ * This includes iframes of assets associated to the AppletIds, not only the main view.
+ *
+ * TODO: Add option to only target main view or specific views
+ *
+ * @param appletIds
+ * @param message
+ * @returns
+ */
+export async function postMessageToAppletIframes(
+  appletIds: { type: 'all' } | { type: 'some'; ids: AppletId[] },
+  message: ParentToAppletMessage,
+  extraOrigins?: Array<string>,
+) {
+  const allIframes = getAllIframes();
+  let allAppletIframes = allIframes.filter(
+    (iframe) => iframe.src.startsWith('applet://') || iframe.src.startsWith('http://localhost'),
+  );
+  if (appletIds.type === 'some') {
+    const relevantSrcs = appletIds.ids.map((id) => appletOriginFromAppletId(id));
+    allAppletIframes = allAppletIframes.filter((iframe) => {
+      console.log('IFRAME SRC: ', iframe.src);
+      let matches = false;
+      if (extraOrigins) {
+        extraOrigins.forEach((origin) => {
+          if (iframe.src.startsWith(origin)) {
+            matches = true;
+          }
+        });
+      }
+      relevantSrcs.forEach((origin) => {
+        if (iframe.src.startsWith(origin)) {
+          matches = true;
+        }
+      });
+      return matches;
+    });
+  }
+  console.log(
+    'Sending postMessate to the following iframes: ',
+    allAppletIframes.map((iframe) => iframe.src),
+  );
+
+  return Promise.allSettled(
+    allAppletIframes.map(async (iframe) => {
+      console.log('seinding msg');
+      await postMessageToIframe(iframe, message);
+      console.log('msg done.');
+    }),
+  );
+}
+
+export async function postMessageToIframe<T>(
+  iframe: HTMLIFrameElement,
+  message: ParentToAppletMessage,
+) {
+  return new Promise<T>((resolve, reject) => {
+    const { port1, port2 } = new MessageChannel();
+
+    if (iframe.contentWindow) {
+      iframe.contentWindow!.postMessage(message, '*', [port2]);
+
+      port1.onmessage = (m) => {
+        if (m.data.type === 'success') {
+          resolve(m.data.result);
+        } else if (m.data.type === 'error') {
+          reject(m.data.error);
+        }
+      };
+    }
+  });
 }

--- a/src/renderer/src/walwindow.ts
+++ b/src/renderer/src/walwindow.ts
@@ -11,8 +11,14 @@ import {
   GroupProfile,
 } from '@theweave/api';
 import { decodeHashFromBase64 } from '@holochain/client';
+import { localized, msg } from '@lit/localize';
+import { postMessageToAppletIframes } from './utils';
+
+import '@shoelace-style/shoelace/dist/components/button/button.js';
+
 // import { ipcRenderer } from 'electron';
 
+@localized()
 @customElement('wal-window')
 export class WalWindow extends LitElement {
   @state()
@@ -21,7 +27,43 @@ export class WalWindow extends LitElement {
   @state()
   appletHash: AppletHash | undefined;
 
+  @state()
+  loading: string | undefined = msg('loading...');
+
+  @state()
+  slowLoading = false;
+
+  @state()
+  slowReloadTimeout: number | undefined;
+
+  @state()
+  onBeforeUnloadHandler: ((e) => Promise<void>) | undefined;
+
+  @state()
+  shouldClose = false;
+
+  beforeUnloadListener = async (e) => {
+    e.preventDefault();
+    console.log('onbeforeunload event');
+    this.loading = 'Saving...';
+    // If it takes longer than 5 seconds to unload, offer to hard reload
+    this.slowReloadTimeout = window.setTimeout(() => {
+      this.slowLoading = true;
+    }, 5000);
+    await postMessageToAppletIframes({ type: 'all' }, { type: 'on-before-unload' });
+    console.log('on-before-unload callbacks finished.');
+    window.removeEventListener('beforeunload', this.beforeUnloadListener);
+    // The logic to set this variable lives in walwindow.html
+    if ((window as any).__WINDOW_CLOSING__) {
+      (window as any).electronAPI.closeWindow();
+    } else {
+      window.location.reload();
+    }
+  };
+
   async firstUpdated() {
+    window.addEventListener('beforeunload', this.beforeUnloadListener);
+
     // set up handler to handle iframe messages
     window.addEventListener('message', async (message) => {
       const request = message.data.request as AppletToParentRequest;
@@ -34,6 +76,7 @@ export class WalWindow extends LitElement {
             case 'user-select-screen':
               return window.electronAPI.selectScreenOrWindow();
             case 'request-close':
+              window.removeEventListener('beforeunload', this.beforeUnloadListener);
               return (window.electronAPI as any).closeWindow();
             case 'user-select-wal': {
               await (window.electronAPI as any).focusMainWindow();
@@ -128,15 +171,64 @@ export class WalWindow extends LitElement {
     }
   }
 
+  hardRefresh() {
+    this.slowLoading = false;
+    window.removeEventListener('beforeunload', this.beforeUnloadListener);
+    // The logic to set this variable lives in walwindow.html
+    if ((window as any).__WINDOW_CLOSING__) {
+      (window as any).electronAPI.closeWindow();
+    } else {
+      window.location.reload();
+    }
+  }
+
+  renderLoading() {
+    return html`
+      <div
+        class="column center-content"
+        style="flex: 1; padding: 0; margin: 0; ${this.loading ? '' : 'display: none'}"
+      >
+        <img src="moss-icon.svg" style="height: 80px; width: 80px;" />
+        <div style="margin-top: 25px; margin-left: 10px; font-size: 24px; color: #142510">
+          ${this.loading}
+        </div>
+        ${this.slowLoading
+          ? html`
+              <div
+                class="column items-center"
+                style="margin-top: 50px; max-width: 600px;color: white;"
+              >
+                <div>This Tool takes unusually long to reload. Do you want to force reload?</div>
+                <div style="margin-top: 10px;">
+                  (force reloading may interrupt the Tool from saving unsaved content)
+                </div>
+                <sl-button
+                  variant="danger"
+                  @click=${() => this.hardRefresh()}
+                  style="margin-top: 20px; width: 150px;"
+                  >Force Reload</sl-button
+                >
+              </div>
+            `
+          : html``}
+      </div>
+    `;
+  }
+
   render() {
     if (!this.iframeSrc) return html`<div class="center-content">Loading...</div>`;
     return html`
       <iframe
+        id="wal-iframe"
         frameborder="0"
         src="${this.iframeSrc}"
-        style="flex: 1; display: block; padding: 0; margin: 0; height: 100vh;"
+        style=${`flex: 1; display: ${this.loading ? 'none' : 'block'}; padding: 0; margin: 0; height: 100vh;`}
         allow="camera *; microphone *; clipboard-write *;"
+        @load=${() => {
+          this.loading = undefined;
+        }}
       ></iframe>
+      ${this.renderLoading()}
     `;
   }
 
@@ -149,6 +241,8 @@ export class WalWindow extends LitElement {
           display: flex;
           margin: 0;
           padding: 0;
+          background-color: #588121;
+          font-family: 'Aileron', 'Open Sans', 'Helvetica Neue', sans-serif;
         }
       `,
     ];

--- a/src/renderer/walwindow.html
+++ b/src/renderer/walwindow.html
@@ -7,11 +7,27 @@
       body {
         margin: 0;
         padding: 0;
+        display: flex;
+        flex: 1;
+        height: 100vh;
       }
     </style>
   </head>
   <body>
+    <!-- code to make on-before-unload working: -->
+    <script>
+      window.electronAPI.onWindowClosing(() => {
+        // This code is required to discern in the window.onbeforeunload callback
+        // whether the onbeforunload event is coming from a page reload or from a
+        // page close
+        window.__WINDOW_CLOSING__ = true;
+      });
+    </script>
     <script type="module" src="/src/walwindow.ts"></script>
+    <script type="module">
+      import '@shoelace-style/shoelace/dist/themes/light.css';
+      import '@fontsource/aileron';
+    </script>
     <wal-window></wal-window>
   </body>
 </html>


### PR DESCRIPTION
Adds an `onBeforeUnload` event that Tools can listen to and run code before they get unloaded.
* gets emitted to a Tool main view if the Tool is reloaded
* gets emitted to all Tool iframes (including assets) if the Moss page or an WAL window page is reloaded
* gets emitted to all Tool iframes (including assets) if Moss is quit

