### PR TITLE
Fix resizing in WAL embed

### DIFF
--- a/libs/elements/README.md
+++ b/libs/elements/README.md
@@ -1,3 +1,28 @@
-# @lightningrodlabs/we-elements
+# @theweave/elements
 
-This package contains UI elements that can be used in We Applets to implement We specific functionality.
+This package contains common UI elements for Weave tools to use Weave Asset Locators (WALs) and for Holochain hApps to know if they are in a Weave context or not.
+
+
+## `wal-embed`
+
+An element for embedding a WAL in an iFrame.
+
+Example use in a lit-element based hApp:
+
+``` html
+<wal-embed
+    style="margin-top: 20px;"
+    src=${this.walEmbedLink}
+    ?bare=${this.bare}
+    closable
+    @open-in-sidebar=${() => console.log('Opening in sidebar')}
+    @close=${() => console.log('Closing requested')}
+    ></wal-embed>
+
+```
+
+## `wal-to-pocket`
+
+## `share-wal`
+
+## `weave-client-context`

--- a/libs/elements/package.json
+++ b/libs/elements/package.json
@@ -4,6 +4,10 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lightningrodlabs/moss"
+  },
   "exports": {
     ".": "./dist/index.js",
     "./dist/*": "./dist/*"

--- a/libs/elements/src/elements/wal-embed.ts
+++ b/libs/elements/src/elements/wal-embed.ts
@@ -262,7 +262,9 @@ export class WalEmbed extends LitElement {
           frameborder="0"
           title="TODO"
           src="${iframeSrc}"
-          style="flex: 1; display: block; padding: 5px; margin: 0; resize: both; width: calc(100% - 10px);"
+          style="flex: 1; display: block; padding: 5px; margin: 0; ${this.bare
+            ? 'resize:both; '
+            : ''} width: calc(100% - 10px);"
           allow="clipboard-write;"
           @load=${() => {
             console.log('iframe loaded.');
@@ -274,12 +276,10 @@ export class WalEmbed extends LitElement {
 
   render() {
     return this.bare
-      ? this.renderContent()
-      : html`
-          <div class="container">
-            ${this.renderHeader()} ${this.collapsed ? '' : this.renderContent()}
-          </div>
-        `;
+      ? html`<div class="container">${this.renderContent()}</div>`
+      : this.collapsed
+        ? html` <div class="container">${this.renderHeader()}</div> `
+        : html` <div class="container">${this.renderHeader()} ${this.renderContent()}</div> `;
   }
 
   static styles = [
@@ -293,6 +293,8 @@ export class WalEmbed extends LitElement {
         resize: both;
         font-family: 'Aileron', 'Open Sans', 'Helvetica Neue', sans-serif;
         overflow: auto;
+        display: flex;
+        flex-direction: column;
       }
 
       .top-bar {


### PR DESCRIPTION
- Turns off `resize:both` to WAL iframe when not in `bare` mode so that there aren't two resize handles.
- Adds `flex` to `wal-embed` element's container so that it will resize properly.  
- Fixes collapse/un-collapse logic so that the element actually shrinks when collapsed.