### PR TITLE
Cloned cells API

### DIFF
--- a/dnas/group/zomes/coordinator/group/src/cloned_cell.rs
+++ b/dnas/group/zomes/coordinator/group/src/cloned_cell.rs
@@ -1,7 +1,7 @@
 use group_integrity::*;
 use hdk::prelude::*;
 
-/// Registeds the Cloned cell in the group DNA. This is probably mainly useful
+/// Registers the cloned cell in the group DNA. This is probably mainly useful
 /// for always-online nodes and has implications for privacy in case that there
 /// are cloned cells that are not supposed to be joined by all group members
 #[hdk_extern]

--- a/dnas/group/zomes/integrity/group/src/cloned_cell.rs
+++ b/dnas/group/zomes/integrity/group/src/cloned_cell.rs
@@ -12,6 +12,8 @@ pub struct AppletClonedCell {
     pub properties: Option<SerializedBytes>,
     pub origin_time: Option<Timestamp>,
     pub quantum_time: Option<Duration>,
+    // NOTE: It might in some cases in the future be desirable to share a membrane proof here
+    // too in case it is not bound to an agent.
 }
 pub fn validate_create_applet_cloned_cell(
     _action: EntryCreationAction,

--- a/example/workdir/happ.yaml
+++ b/example/workdir/happ.yaml
@@ -1,14 +1,14 @@
 ---
-manifest_version: "1"
+manifest_version: '1'
 name: example-applet
-description: "Example forum app"
+description: 'Example forum app'
 roles:
   - name: forum
     provisioning:
       strategy: create
       deferred: false
     dna:
-      bundled: "../dnas/forum/workdir/forum.dna"
+      bundled: '../dnas/forum/workdir/forum.dna'
       modifiers:
         network_seed: ~
         properties: ~
@@ -16,4 +16,4 @@ roles:
         quantum_time: ~
       installed_hash: ~
       version: ~
-      clone_limit: 0
+      clone_limit: 10

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -593,6 +593,10 @@ async function setupAppClient(appPort: number, token: AppAuthenticationToken) {
     },
   });
 
+  appletClient.createCloneCell = (_) => {
+    throw new Error('Please use the createCloneCell method on the WeaveClient instead.');
+  };
+
   return appletClient;
 }
 

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -8,6 +8,9 @@ import {
   AppWebsocket,
   CallZomeRequest,
   CallZomeRequestSigned,
+  CreateCloneCellRequest,
+  DisableCloneCellRequest,
+  EnableCloneCellRequest,
   EntryHash,
   decodeHashFromBase64,
   encodeHashToBase64,
@@ -307,6 +310,25 @@ const weaveApi: WeaveServices = {
     window.addEventListener('remote-signal-received', listener);
     return () => window.removeEventListener('remote-signal-received', listener);
   },
+
+  createCloneCell: (req: CreateCloneCellRequest, publicToGroupMembers: boolean) =>
+    postMessage({
+      type: 'create-clone-cell',
+      req,
+      publicToGroupMembers,
+    }),
+
+  enableCloneCell: (req: EnableCloneCellRequest) =>
+    postMessage({
+      type: 'enable-clone-cell',
+      req,
+    }),
+
+  disableCloneCell: (req: DisableCloneCellRequest) =>
+    postMessage({
+      type: 'disable-clone-cell',
+      req,
+    }),
 };
 
 (async () => {
@@ -614,7 +636,7 @@ async function setupProfilesClient(
 ) {
   const client = await setupAppClient(appPort, token);
 
-  return new ProfilesClient(client, roleName);
+  return new ProfilesClient(client as any, roleName);
 }
 
 async function signZomeCall(request: CallZomeRequest): Promise<CallZomeRequestSigned> {

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -636,7 +636,7 @@ async function setupProfilesClient(
 ) {
   const client = await setupAppClient(appPort, token);
 
-  return new ProfilesClient(client as any, roleName);
+  return new ProfilesClient(client, roleName);
 }
 
 async function signZomeCall(request: CallZomeRequest): Promise<CallZomeRequestSigned> {

--- a/libs/api/src/api.ts
+++ b/libs/api/src/api.ts
@@ -2,6 +2,10 @@ import {
   ActionHash,
   AgentPubKey,
   AppClient,
+  CreateCloneCellRequest,
+  CreateCloneCellResponse,
+  DisableCloneCellRequest,
+  EnableCloneCellRequest,
   EntryHash,
   decodeHashFromBase64,
   encodeHashToBase64,
@@ -406,6 +410,24 @@ export interface WeaveServices {
    * @returns
    */
   onRemoteSignal: (callback: (payload: Uint8Array) => any) => UnsubscribeFunction;
+
+  /**
+   * Create a cloned cell and optionally have it be registered in the group DNA for other
+   * group members or always-online nodes to be able to automatically join it too.
+   *
+   * @param req
+   * @param publicToGroupMembers Whether this cloned cell should be registered in the group DNA such that
+   * other group members or alway-online nodes may automatically install it too.
+   * @returns
+   */
+  createCloneCell: (
+    req: CreateCloneCellRequest,
+    publicToGroupMembers: boolean,
+  ) => Promise<CreateCloneCellResponse>;
+
+  enableCloneCell: (req: EnableCloneCellRequest) => Promise<CreateCloneCellResponse>;
+
+  disableCloneCell: (req: DisableCloneCellRequest) => Promise<void>;
 }
 
 export class WeaveClient implements WeaveServices {
@@ -500,4 +522,11 @@ export class WeaveClient implements WeaveServices {
 
   onRemoteSignal = (callback: (payload: Uint8Array) => any) =>
     window.__WEAVE_API__.onRemoteSignal(callback);
+
+  createCloneCell = (req: CreateCloneCellRequest, publicToGroupMembers: boolean) =>
+    window.__WEAVE_API__.createCloneCell(req, publicToGroupMembers);
+
+  enableCloneCell = (req: EnableCloneCellRequest) => window.__WEAVE_API__.enableCloneCell(req);
+
+  disableCloneCell = (req: DisableCloneCellRequest) => window.__WEAVE_API__.disableCloneCell(req);
 }

--- a/libs/api/src/types.ts
+++ b/libs/api/src/types.ts
@@ -12,6 +12,9 @@ import {
   AppAuthenticationToken,
   AgentPubKeyB64,
   AgentPubKey,
+  CreateCloneCellRequest,
+  DisableCloneCellRequest,
+  EnableCloneCellRequest,
 } from '@holochain/client';
 
 export type AppletHash = EntryHash;
@@ -394,6 +397,19 @@ export type AppletToParentRequest =
   | {
       type: 'send-remote-signal';
       payload: Uint8Array;
+    }
+  | {
+      type: 'create-clone-cell';
+      req: CreateCloneCellRequest;
+      publicToGroupMembers: boolean;
+    }
+  | {
+      type: 'disable-clone-cell';
+      req: DisableCloneCellRequest;
+    }
+  | {
+      type: 'enable-clone-cell';
+      req: EnableCloneCellRequest;
     }
   /**
    * Asset related requests

--- a/shared/group-client/src/types.ts
+++ b/shared/group-client/src/types.ts
@@ -206,10 +206,13 @@ export type AppletClonedCell = {
   applet_hash: EntryHash;
   dna_hash: DnaHash;
   role_name: String;
-  network_seed: String;
-  properties: Uint8Array;
-  origin_time: Timestamp;
-  quantum_time: Duration;
+  network_seed?: String;
+  /**
+   * Any yaml serializable properties
+   */
+  properties?: unknown;
+  origin_time?: Timestamp;
+  quantum_time?: Duration;
 };
 
 export type TagsToAssetInput = {

--- a/src/renderer/src/validationSchemas.ts
+++ b/src/renderer/src/validationSchemas.ts
@@ -18,6 +18,7 @@ const AgentPubKey = Type.Uint8Array({ minByteLength: 39, maxByteLength: 39 });
 // const AgentPubKeyB64 = Type.String({ pattern: '^uhCAk' });
 
 const CellId = Type.Tuple([DnaHash, AgentPubKey]);
+const RoleName = Type.String();
 const ZomeName = Type.String();
 const FunctionName = Type.String();
 
@@ -32,6 +33,49 @@ const CallZomeRequest = Type.Object(
   },
   { additionalProperties: false },
 );
+
+const MembraneProof = Type.Uint8Array();
+const Timestamp = Type.Number();
+/**
+ * Any Yaml serializable properties
+ */
+const DnaProperties = Type.Unknown();
+const Duration = Type.Object(
+  {
+    secs: Type.Number(),
+    nanos: Type.Number(),
+  },
+  { additionalProperties: false },
+);
+
+const DnaModifiersOpt = Type.Object(
+  {
+    network_seed: Type.Optional(Type.String()),
+    properties: Type.Optional(DnaProperties),
+    origin_time: Type.Optional(Timestamp),
+    quantum_time: Type.Optional(Duration),
+  },
+  { additionalProperties: false },
+);
+
+const CreateCloneCellRequest = Type.Object(
+  {
+    role_name: RoleName,
+    modifiers: DnaModifiersOpt,
+    membrane_proof: Type.Optional(MembraneProof),
+    name: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const DisableCloneCellRequest = Type.Object(
+  {
+    clone_cell_id: Type.Union([RoleName, DnaHash]),
+  },
+  { additionalProperties: false },
+);
+
+const EnableCloneCellRequest = DisableCloneCellRequest;
 
 // const AppAuthenticationToken = Type.Array(Type.Number());
 
@@ -319,6 +363,28 @@ export const AppletToParentRequest = Type.Union([
     {
       type: Type.Literal('send-remote-signal'),
       payload: Type.Uint8Array(),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal('create-clone-cell'),
+      req: CreateCloneCellRequest,
+      publicToGroupMembers: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal('enable-clone-cell'),
+      req: EnableCloneCellRequest,
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal('disable-clone-cell'),
+      req: DisableCloneCellRequest,
     },
     { additionalProperties: false },
   ),


### PR DESCRIPTION
This PR adds a `createCloneCell` method to the `WeaveClient` and makes the one on the appletClient fail. This is to be able to distinguish between cloned cells that should be registered in the group dna and ones that shouldn't.