### PR TITLE
fix: workaround for the will-navigate and beforeunload timing issue

### DIFF
--- a/example/ui/src/example-applet.ts
+++ b/example/ui/src/example-applet.ts
@@ -46,8 +46,9 @@ export class ExampleApplet extends LitElement {
 
   firstUpdated() {
     this.onBeforeUnloadUnsubscribe = this.weaveClient.onBeforeUnload(async () => {
-      console.log('Unloading in 10 seconds');
-      await new Promise((resolve) => setTimeout(resolve, 10000));
+      // Uncomment below to test that unloading after force reload timeout works
+      // console.log('Unloading in 10 seconds');
+      // await new Promise((resolve) => setTimeout(resolve, 10000));
       console.log('Unloading now.');
     });
     // To test whether applet iframe properly gets removed after disabling applet.

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -346,7 +346,7 @@ const weaveApi: WeaveServices = {
   window.addEventListener('message', async (m: MessageEvent<any>) => {
     try {
       const result = await handleEventMessage(m.data);
-      // Only send result succcess if truthy, indicating that the message was
+      // Only send result success if truthy, indicating that the message was
       // actually handled, otherwise the `handleMessage` message handler further
       // below will be ignored
       if (result) m.ports[0].postMessage({ type: 'success', result });

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -37,6 +37,9 @@ export function setLinkOpenHandlers(browserWindow: BrowserWindow): void {
       e.url.startsWith('mailto:')
     ) {
       e.preventDefault();
+      // This event is emitted to allow the window to prevent the
+      // beforeunload event to execute
+      emitToWindow(browserWindow, 'will-navigate-external', null);
       shell.openExternal(e.url);
     }
   });
@@ -58,6 +61,9 @@ export function setLinkOpenHandlers(browserWindow: BrowserWindow): void {
       e.url.startsWith('mailto:')
     ) {
       e.preventDefault();
+      // This event is emitted to allow the window to prevent the
+      // beforeunload event to execute
+      emitToWindow(browserWindow, 'will-navigate-external', null);
       shell.openExternal(e.url);
     }
   });

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -59,6 +59,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('switch-to-applet', callback),
   onWindowClosing: (callback: (e: Electron.IpcRendererEvent) => any) =>
     ipcRenderer.on('window-closing', callback),
+  onWillNavigateExternal: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('will-navigate-external', callback),
+  removeWillNavigateListeners: () => ipcRenderer.removeAllListeners('will-navigate-external'),
   onZomeCallSigned: (
     callback: (
       e: Electron.IpcRendererEvent,

--- a/src/preload/walwindow.ts
+++ b/src/preload/walwindow.ts
@@ -21,6 +21,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       forApplets: AppletId[],
     ) => any,
   ) => ipcRenderer.on('parent-to-applet-message', callback),
+  onWillNavigateExternal: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('will-navigate-external', callback),
+  removeWillNavigateListeners: () => ipcRenderer.removeAllListeners('will-navigate-external'),
   selectScreenOrWindow: () => ipcRenderer.invoke('select-screen-or-window'),
   setMyIcon: (icon: string) => ipcRenderer.invoke('set-my-icon', icon),
   setMyTitle: (title: string) => ipcRenderer.invoke('set-my-title', title),

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -55,6 +55,8 @@ declare global {
       onSwitchToApplet: (callback: (e: any, payload: AppletId) => any) => void;
       onMossUpdateProgress: (callback: (e: any, payload: ProgressInfo) => any) => void;
       onRequestFactoryReset: (callback: (e: any) => any) => void;
+      onWillNavigateExternal: (callback: (e: any) => any) => void;
+      removeWillNavigateListeners: () => void;
       onZomeCallSigned: (
         callback: (
           e: any,

--- a/src/renderer/src/elements/main-dashboard.ts
+++ b/src/renderer/src/elements/main-dashboard.ts
@@ -493,23 +493,43 @@ export class MainDashboard extends LitElement {
   }
 
   beforeUnloadListener = async (e) => {
+    console.log('GOT BEFOREUNLOAD EVENT: ', e);
+    // Wait first to check whether it's triggered by a will-navigate or will-frame-navigate
+    // event to an external location (https, mailto, ...) and this listener should therefore
+    // not be executed (https://github.com/electron/electron/issues/29921)
+    let shouldProceed = true;
+    await new Promise((resolve) => {
+      window.electronAPI.onWillNavigateExternal(() => {
+        shouldProceed = false;
+        window.electronAPI.removeWillNavigateListeners();
+        resolve(null);
+      });
+      setTimeout(() => {
+        resolve(null);
+      }, 500);
+    });
+
     e.preventDefault();
-    this.reloading = true;
-    console.log('onbeforeunload event');
-    // If it takes longer than 5 seconds to unload, offer to hard reload
-    this.slowReloadTimeout = window.setTimeout(() => {
-      this.slowLoading = true;
-    }, 4500);
-    await postMessageToAppletIframes({ type: 'all' }, { type: 'on-before-unload' });
-    console.log('on-before-unload callbacks finished.');
-    window.removeEventListener('beforeunload', this.beforeUnloadListener);
-    // The logic to set this variable lives in index.html
-    window.location.reload();
-    if ((window as any).__WINDOW_CLOSING__) {
-      console.log('__WINDOW_CLOSING__ is true.');
-      window.electronAPI.closeMainWindow();
-    } else {
+
+    if (shouldProceed) {
+      e.preventDefault();
+      this.reloading = true;
+      console.log('onbeforeunload event');
+      // If it takes longer than 5 seconds to unload, offer to hard reload
+      this.slowReloadTimeout = window.setTimeout(() => {
+        this.slowLoading = true;
+      }, 4500);
+      await postMessageToAppletIframes({ type: 'all' }, { type: 'on-before-unload' });
+      console.log('on-before-unload callbacks finished.');
+      window.removeEventListener('beforeunload', this.beforeUnloadListener);
+      // The logic to set this variable lives in index.html
       window.location.reload();
+      if ((window as any).__WINDOW_CLOSING__) {
+        console.log('__WINDOW_CLOSING__ is true');
+        window.electronAPI.closeMainWindow();
+      } else {
+        window.location.reload();
+      }
     }
   };
 


### PR DESCRIPTION
This is a workaround for https://github.com/electron/electron/issues/29921 which caused the page to reload sometimes when clicking on external links because the beforeunload event can be triggered before the will-frame-navigate event is being triggered in the backend.