### PR TITLE
Refactor: Register all iframes

### DIFF
--- a/example/ui/src/elements/post-detail.ts
+++ b/example/ui/src/elements/post-detail.ts
@@ -98,6 +98,9 @@ export class PostDetail extends LitElement {
       this.assetStoreContent = val;
       this.requestUpdate();
     });
+    this.weaveClient.onPeerStatusUpdate((update) => {
+      console.log('@post-detail: Got peer-status-update: ', update);
+    });
   }
 
   async deletePost() {

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -356,7 +356,6 @@ const weaveApi: WeaveServices = {
   const iframeId = Math.random().toString(36).substring(2);
 
   window.addEventListener('beforeunload', () => {
-    // unregister iframe
     postMessage({ type: 'unregister-iframe', id: iframeId });
   });
 

--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -353,8 +353,17 @@ const weaveApi: WeaveServices = {
     throw new Error('RenderView undefined.');
   }
 
+  const iframeId = Math.random().toString(36).substring(2);
+
+  window.addEventListener('beforeunload', () => {
+    // unregister iframe
+    postMessage({ type: 'unregister-iframe', id: iframeId });
+  });
+
   const iframeConfig: IframeConfig = await postMessage({
     type: 'get-iframe-config',
+    id: iframeId,
+    subType: view.view.type,
   });
 
   if (iframeConfig.type === 'not-installed') {
@@ -427,7 +436,9 @@ const weaveApi: WeaveServices = {
       }
       try {
         const result = await handleMessage(appletClient, appletHash, m.data);
-        m.ports[0].postMessage({ type: 'success', result });
+        // Messages sent from MossStore.postMessageToAppletIframes() won't have
+        // a port attached here, only the ones sent from AppletHost
+        m.ports[0]?.postMessage({ type: 'success', result });
       } catch (e) {
         console.error(
           'Failed to send postMessage to applet ',

--- a/libs/api/src/types.ts
+++ b/libs/api/src/types.ts
@@ -339,7 +339,16 @@ export type AppletToParentRequest =
   | {
       // This one is used by initializeHotReload() and is the only one that
       // affects the API exposed to tool devs
+      //
+      // It's also used as a means to register the iframe in order for Moss
+      // to be able to send messages to it
       type: 'get-iframe-config';
+      id: string;
+      subType: 'main' | 'asset' | 'block' | 'creatable';
+    }
+  | {
+      type: 'unregister-iframe';
+      id: string;
     }
   | {
       type: 'get-record-info';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -931,13 +931,22 @@ if (!RUNNING_WITH_COMMAND) {
       'parent-to-applet-message',
       (_e, message: ParentToAppletMessage, forApplets: AppletId[]) => {
         // We send this to all wal windows as they may also contain embeddables
-        console.log('Sending parent-to-applet-message to windows. Message: ', message);
-        console.log('Sending parent-to-applet-message to windows. forApplets: ', forApplets);
         Object.values(WAL_WINDOWS).forEach(({ window }) =>
           emitToWindow(window, 'parent-to-applet-message', { message, forApplets }),
         );
       },
     );
+    // This is called by the main window if it's being reloaded, in order to re-sync the
+    // IframeStore
+    ipcMain.handle('request-iframe-store-sync', (): void => {
+      Object.values(WAL_WINDOWS).forEach(({ window }) =>
+        emitToWindow(window, 'request-iframe-store-sync', null),
+      );
+    });
+    // Called by WAL windows to send their IframeStore state to the main window
+    ipcMain.handle('iframe-store-sync', (_e, storeContent): void => {
+      if (MAIN_WINDOW) emitToWindow(MAIN_WINDOW, 'iframe-store-sync', storeContent);
+    });
     ipcMain.handle('get-app-version', (): string => app.getVersion());
     ipcMain.handle(
       'dialog-messagebox',

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -57,6 +57,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('window-closing', callback),
   onWillNavigateExternal: (callback: (e: Electron.IpcRendererEvent) => any) =>
     ipcRenderer.on('will-navigate-external', callback),
+  onIframeStoreSync: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('iframe-store-sync', callback),
+  requestIframeStoreSync: () => ipcRenderer.invoke('request-iframe-store-sync'),
   removeWillNavigateListeners: () => ipcRenderer.removeAllListeners('will-navigate-external'),
   closeMainWindow: () => ipcRenderer.invoke('close-main-window'),
   openApp: (appId: string) => ipcRenderer.invoke('open-app', appId),

--- a/src/preload/walwindow.ts
+++ b/src/preload/walwindow.ts
@@ -24,6 +24,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ) => ipcRenderer.on('parent-to-applet-message', callback),
   onWillNavigateExternal: (callback: (e: Electron.IpcRendererEvent) => any) =>
     ipcRenderer.on('will-navigate-external', callback),
+  onRequestIframeStoreSync: (callback: (e: Electron.IpcRendererEvent) => any) =>
+    ipcRenderer.on('request-iframe-store-sync', callback),
+  iframeStoreSync: (storeContent) => ipcRenderer.invoke('iframe-store-sync', storeContent),
   removeWillNavigateListeners: () => ipcRenderer.removeAllListeners('will-navigate-external'),
   selectScreenOrWindow: () => ipcRenderer.invoke('select-screen-or-window'),
   setMyIcon: (icon: string) => ipcRenderer.invoke('set-my-icon', icon),

--- a/src/preload/walwindow.ts
+++ b/src/preload/walwindow.ts
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   focusMainWindow: () => ipcRenderer.invoke('focus-main-window'),
   focusMyWindow: () => ipcRenderer.invoke('focus-my-window'),
   getMySrc: () => ipcRenderer.invoke('get-my-src'),
+  isAppletDev: () => ipcRenderer.invoke('is-applet-dev'),
   onWindowClosing: (callback: (e: Electron.IpcRendererEvent) => any) =>
     ipcRenderer.on('window-closing', callback),
   onParentToAppletMessage: (

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -59,6 +59,30 @@ declare global {
       onMossUpdateProgress: (callback: (e: any, payload: ProgressInfo) => any) => void;
       onRequestFactoryReset: (callback: (e: any) => any) => void;
       onWillNavigateExternal: (callback: (e: any) => any) => void;
+      onIframeStoreSync: (
+        callback: (
+          e: Electron.IpcRendererEvent,
+          payload: [
+            Record<
+              AppletId,
+              Array<{
+                id: string;
+                subType: string;
+                source: MessageEventSource | null | 'wal-window';
+              }>
+            >,
+            Record<
+              ToolCompatibilityId,
+              Array<{
+                id: string;
+                subType: string;
+                source: MessageEventSource | null | 'wal-window';
+              }>
+            >,
+          ],
+        ) => any,
+      ) => void;
+      requestIframeStoreSync: () => void;
       removeWillNavigateListeners: () => void;
       onZomeCallSigned: (
         callback: (

--- a/src/renderer/src/elements/debugging-panel/debugging-panel.ts
+++ b/src/renderer/src/elements/debugging-panel/debugging-panel.ts
@@ -448,6 +448,16 @@ export class DebuggingPanel extends LitElement {
             ></sl-switch>
           </div>
         </div>
+        <div class="column" v style="margin-top: 10px;">
+          <div>
+            Total number of applet iframes:
+            <b>${this._mossStore.iframeStore.appletIframesTotalCount()}</b>
+          </div>
+          <div>
+            Total number of cross-group iframes:
+            <b>${this._mossStore.iframeStore.crossGroupIframesTotalCount()}</b>
+          </div>
+        </div>
         <h2 style="text-align: center;">Global Apps</h2>
         <div class="center-content" style="text-align: center;">No global apps installed.</div>
         <sl-button

--- a/src/renderer/src/elements/debugging-panel/debugging-panel.ts
+++ b/src/renderer/src/elements/debugging-panel/debugging-panel.ts
@@ -266,7 +266,7 @@ export class DebuggingPanel extends LitElement {
                         @click=${() => this.toggleGroupDetails(groupId)}
                         >${showDetails ? 'Hide' : 'Details'}</span
                       >`
-                    : html``}
+                    : html`<span style="min-width: 60px;"></span>`}
 
                   <sl-icon-button
                     @click=${async () => {
@@ -323,6 +323,7 @@ export class DebuggingPanel extends LitElement {
             const zomeCallCount = this._mossStore.zomeCallLogs[appId];
             const showDetails = this._appletsWithDetails.includes(appletId);
             const showDebug = this._appsWithDebug.includes(appId);
+            const iframeCounts = this._mossStore.iframeStore.appletIframesCounts(appletId);
             return html`
               <div class="column">
                 <div class="row" style="align-items: center; flex: 1;">
@@ -331,8 +332,18 @@ export class DebuggingPanel extends LitElement {
                       .appletHash=${appletHash}
                       style="margin-top: 2px; margin-bottom: 2px; margin-right: 12px; --size: 48px"
                     ></applet-logo>
-                    <div style="font-weight: bold; font-size: 18px;">
-                      ${appletStore.applet.custom_name}
+                    <div class="column">
+                      <div style="font-weight: bold; font-size: 18px;">
+                        ${appletStore.applet.custom_name}
+                      </div>
+                      <div>
+                        <b>iframes:</b>
+                        ${iframeCounts
+                          ? Object.entries(iframeCounts).map(
+                              ([viewType, count]) => html`${viewType} (${count}) `,
+                            )
+                          : html``}
+                      </div>
                     </div>
                   </div>
                   <div style="display: flex; flex: 1;"></div>
@@ -359,7 +370,7 @@ export class DebuggingPanel extends LitElement {
                         @click=${() => this.toggleAppletDetails(appletId)}
                         >${showDetails ? 'Hide' : 'Details'}</span
                       >`
-                    : html``}
+                    : html`<span style="min-width: 60px;"></span>`}
                   <sl-icon-button
                     @click=${async () => {
                       this.toggleDebug(appId);
@@ -416,12 +427,12 @@ export class DebuggingPanel extends LitElement {
   render() {
     return html`
       <div class="column" style="height: calc(100vh - 140px); padding: 30px; overflow-y: auto;">
-        <div class=" warning column center-content">
+        <div class="warning column center-content">
           <div class="row items-center">
             <div>
               ${window.__ZOME_CALL_LOGGING_ENABLED__
-                ? 'Enable zome call logging (will reload Moss)'
-                : 'Disable zome call logging (will reload Moss)'}
+                ? 'Disable zome call logging (will reload Moss)'
+                : 'Enable zome call logging (will reload Moss)'}
             </div>
             <sl-switch
               style="margin-bottom: 5px; margin-left: 12px;"

--- a/src/renderer/src/elements/main-dashboard.ts
+++ b/src/renderer/src/elements/main-dashboard.ts
@@ -575,7 +575,6 @@ export class MainDashboard extends LitElement {
 
     window.addEventListener('message', appletMessageHandler(this._mossStore, this.openViews));
     window.electronAPI.onAppletToParentMessage(async (_e, payload) => {
-      console.log('Got cross window applet to parent message: ', payload);
       if (!payload.message.source) throw new Error('source not defined in AppletToParentMessage');
       const response = await handleAppletIframeMessage(
         this._mossStore,
@@ -586,6 +585,27 @@ export class MainDashboard extends LitElement {
       );
       await window.electronAPI.appletMessageToParentResponse(response, payload.id);
     });
+
+    // Received from WAL windows on request when the main window is reloaded
+    window.electronAPI.onIframeStoreSync((_e, payload) => {
+      const [appletIframes, crossGroupIframes] = payload;
+      Object.entries(appletIframes).forEach(([appletId, iframes]) => {
+        iframes.forEach(({ id, subType }) => {
+          this._mossStore.iframeStore.registerAppletIframe(appletId, id, subType, 'wal-window');
+        });
+      });
+      Object.entries(crossGroupIframes).forEach(([toolCompatibilityId, iframes]) => {
+        iframes.forEach(({ id, subType }) => {
+          this._mossStore.iframeStore.registerCrossGroupIframe(
+            toolCompatibilityId,
+            id,
+            subType,
+            'wal-window',
+          );
+        });
+      });
+    });
+
     window.electronAPI.onSwitchToApplet((_, appletId) => {
       if (appletId) {
         this.openViews.openAppletMain(decodeHashFromBase64(appletId));
@@ -667,6 +687,8 @@ export class MainDashboard extends LitElement {
     } catch (e) {
       console.warn('Failed to fetch update feed: ', e);
     }
+
+    await window.electronAPI.requestIframeStoreSync();
 
     // Load all notifications for the last week
     await this._mossStore.loadNotificationFeed(7);
@@ -1392,7 +1414,6 @@ export class MainDashboard extends LitElement {
             class="drawer-separator"
             style="${this._assetViewerState.value.visible ? '' : 'display: none;'}"
             @mousedown=${(e) => {
-              console.log('Got mousedown event: ', e);
               this.resizeMouseDownHandler(e);
             }}
           ></div>

--- a/src/renderer/src/elements/main-dashboard.ts
+++ b/src/renderer/src/elements/main-dashboard.ts
@@ -70,7 +70,6 @@ import { AppOpenViews } from '../layout/types.js';
 import {
   decodeContext,
   getAllIframes,
-  postMessageToAppletIframes,
   postMessageToIframe,
   progenitorFromProperties,
 } from '../utils.js';
@@ -549,7 +548,10 @@ export class MainDashboard extends LitElement {
       this.slowReloadTimeout = window.setTimeout(() => {
         this.slowLoading = true;
       }, 4500);
-      await postMessageToAppletIframes({ type: 'all' }, { type: 'on-before-unload' });
+      await this._mossStore.iframeStore.postMessageToAppletIframes(
+        { type: 'all' },
+        { type: 'on-before-unload' },
+      );
       console.log('on-before-unload callbacks finished.');
       window.removeEventListener('beforeunload', this.beforeUnloadListener);
       // The logic to set this variable lives in index.html
@@ -580,6 +582,7 @@ export class MainDashboard extends LitElement {
         this.openViews,
         payload.message.source,
         payload.message.request,
+        'wal-window',
       );
       await window.electronAPI.appletMessageToParentResponse(response, payload.id);
     });

--- a/src/renderer/src/groups/elements/group-home.ts
+++ b/src/renderer/src/groups/elements/group-home.ts
@@ -216,7 +216,7 @@ export class GroupHome extends LitElement {
 
   async firstUpdated() {
     this._peerStatusInterval = window.setInterval(async () => {
-      await this.groupStore.emitToAppletHosts({
+      await this.groupStore.emitToGroupApplets({
         type: 'peer-status-update',
         payload: this._peersStatus.value ? this._peersStatus.value : {},
       });

--- a/src/renderer/src/groups/group-store.ts
+++ b/src/renderer/src/groups/group-store.ts
@@ -1209,6 +1209,16 @@ export class GroupStore {
       }),
     );
   }
+
+  async emitToGroupApplets(message: ParentToAppletMessage): Promise<void> {
+    const appletHashes = await toPromise(this.allMyRunningApplets);
+    // __PERFORMANCE__ TODO possibly store base64 versions of hashes already in group store
+    // instead of encoding each time
+    await this.mossStore.emitParentToAppletMessage(
+      message,
+      appletHashes.map((hash) => encodeHashToBase64(hash)),
+    );
+  }
 }
 
 async function retryUntilResolved<T>(

--- a/src/renderer/src/iframe-store.ts
+++ b/src/renderer/src/iframe-store.ts
@@ -1,0 +1,123 @@
+import { AppletId, ParentToAppletMessage } from '@theweave/api';
+import { ToolCompatibilityId } from '@theweave/moss-types';
+
+/**
+ * Stores references to iframes and allows to send iframe messages
+ * to them
+ */
+export class IframeStore {
+  constructor() {}
+
+  appletIframes: Record<
+    AppletId,
+    Array<{ id: string; subType: string; source: MessageEventSource | null | 'wal-window' }>
+  > = {};
+
+  crossGroupIframes: Record<
+    ToolCompatibilityId,
+    Array<{ id: string; subType: string; source: MessageEventSource | null | 'wal-window' }>
+  > = {};
+
+  registerAppletIframe(
+    appletId: AppletId,
+    id: string,
+    subType: string,
+    source: MessageEventSource | null | 'wal-window',
+  ): void {
+    console.log(`### Registering ${subType} iframe for applet ${appletId}`);
+    let iframes = this.appletIframes[appletId];
+    if (!iframes) iframes = [];
+    iframes.push({ id, subType, source });
+    this.appletIframes[appletId] = iframes;
+  }
+
+  unregisterAppletIframe(appletId: AppletId, idToRemove: string): void {
+    let iframes = this.appletIframes[appletId];
+    this.appletIframes[appletId] = iframes.filter(({ id }) => id !== idToRemove);
+  }
+
+  registerCrossGroupIframe(
+    toolCompatibilityId: ToolCompatibilityId,
+    id: string,
+    subType: string,
+    source: MessageEventSource | null | 'wal-window',
+  ): void {
+    let iframes = this.crossGroupIframes[toolCompatibilityId];
+    if (!iframes) iframes = [];
+    iframes.push({ id, subType, source });
+    this.crossGroupIframes[toolCompatibilityId] = iframes;
+  }
+
+  unregisterCrossGroupIframe(toolCompatibilityId: ToolCompatibilityId, idToRemove: string): void {
+    let iframes = this.crossGroupIframes[toolCompatibilityId];
+    this.crossGroupIframes[toolCompatibilityId] = iframes.filter(({ id }) => id !== idToRemove);
+  }
+
+  appletIframesTotalCount(): number {
+    return Object.values(this.appletIframes).flat().length;
+  }
+
+  crossGroupIframesTotalCount(): number {
+    return Object.values(this.crossGroupIframes).flat().length;
+  }
+
+  appletIframesCounts(appletId: AppletId): Record<string, number> {
+    const iframes = this.appletIframes[appletId];
+    const iframeCounts = {};
+    if (!iframes) return iframeCounts;
+    iframes.forEach(({ subType }) => {
+      let count = iframeCounts[subType];
+      if (!count) count = 0;
+      count += 1;
+      iframeCounts[subType] = count;
+    });
+    return iframeCounts;
+  }
+
+  crossGroupIframesCounts(toolCompatibilityId: ToolCompatibilityId): Record<string, number> {
+    const iframes = this.crossGroupIframes[toolCompatibilityId];
+    const iframeCounts = {};
+    if (!iframes) return iframeCounts;
+    iframes.forEach(({ subType }) => {
+      let count = iframeCounts[subType];
+      if (!count) count = 0;
+      count += 1;
+      iframeCounts[subType] = count;
+    });
+    return iframeCounts;
+  }
+
+  /**
+   * Posts a message to all iframes of the specified AppletIds and returns the settled promises.
+   * This includes iframes of assets associated to the AppletIds, not only the main view.
+   *
+   * TODO: Add option to only target main view or specific views
+   *
+   * @param appletIds
+   * @param message
+   * @returns
+   */
+  async postMessageToAppletIframes(
+    appletIds: { type: 'all' } | { type: 'some'; ids: AppletId[] },
+    message: ParentToAppletMessage,
+  ) {
+    const relevantIframes: MessageEventSource[] = [];
+    const relevantAppletIds =
+      appletIds.type === 'all' ? Object.keys(this.appletIframes) : appletIds.ids;
+
+    relevantAppletIds.forEach((appletId) => {
+      const iframes = this.appletIframes[appletId];
+      if (iframes) {
+        iframes.forEach(({ source }) => {
+          if (source && source !== 'wal-window') relevantIframes.push(source);
+        });
+      }
+    });
+
+    return Promise.allSettled(
+      relevantIframes.map(async (iframe) => {
+        await iframe.postMessage(message, { targetOrigin: '*' });
+      }),
+    );
+  }
+}

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -1688,7 +1688,6 @@ export class MossStore {
     // Send to iframes of main window
     this.iframeStore.postMessageToAppletIframes({ type: 'some', ids: forApplets }, message);
     // Send to iframes of WAL windows
-    console.log('@MossStore: emitParentToAppletMessage. Message: ', message);
     return window.electronAPI.parentToAppletMessage(message, forApplets);
   }
 }

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -70,7 +70,6 @@ import {
   findAppForDnaHash,
   isAppDisabled,
   isAppRunning,
-  postMessageToAppletIframes,
   validateWal,
 } from './utils.js';
 import { AppletStore } from './applets/applet-store.js';
@@ -111,6 +110,7 @@ import { AssetViewerState, DashboardState } from './elements/main-dashboard.js';
 import { PersistedStore } from './persisted-store.js';
 import { MossCache } from './cache.js';
 import { compareVersions } from 'compare-versions';
+import { IframeStore } from './iframe-store.js';
 
 export type SearchStatus = 'complete' | 'loading';
 
@@ -201,6 +201,14 @@ export class MossStore {
     this._appletDevPorts = appletPorts;
     return port;
   }
+
+  /**
+   * --------------------------------------------------------------------------
+   * iframe references and logic to post messages to them
+   * --------------------------------------------------------------------------
+   */
+
+  iframeStore = new IframeStore();
 
   /**
    * --------------------------------------------------------------------------
@@ -1678,7 +1686,7 @@ export class MossStore {
 
   async emitParentToAppletMessage(message: ParentToAppletMessage, forApplets: AppletId[]) {
     // Send to iframes of main window
-    postMessageToAppletIframes({ type: 'some', ids: forApplets }, message);
+    this.iframeStore.postMessageToAppletIframes({ type: 'some', ids: forApplets }, message);
     // Send to iframes of WAL windows
     console.log('@MossStore: emitParentToAppletMessage. Message: ', message);
     return window.electronAPI.parentToAppletMessage(message, forApplets);

--- a/src/renderer/src/validationSchemas.ts
+++ b/src/renderer/src/validationSchemas.ts
@@ -237,9 +237,23 @@ export const AppletToParentRequest = Type.Union([
   Type.Object(
     {
       type: Type.Literal('get-iframe-config'),
+      id: Type.String(),
+      subType: Type.Union([
+        Type.Literal('main'),
+        Type.Literal('asset'),
+        Type.Literal('creatable'),
+        Type.Literal('block'),
+      ]),
       // TODO remove the crossGroup field altogether once it's removed in @theweave/api
       // since it's not required anymore
       crossGroup: Type.Optional(Type.Boolean()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal('unregister-iframe'),
+      id: Type.String(),
     },
     { additionalProperties: false },
   ),


### PR DESCRIPTION
Switches to registering all iframes as part of the applet-iframe script and send `ParentToAppletMessage`s to these registered iframes rather than scraping the DOM to find iframes (which did not actually find nested iframes).