### PR TITLE
fix ice server format

### DIFF
--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -93,7 +93,7 @@ export class HolochainManager {
     // network parameters
     conductorConfig.network.bootstrap_url = bootstrapUrl;
     conductorConfig.network.signal_url = signalUrl;
-    conductorConfig.network.webrtc_config = { iceServers: iceUrls };
+    conductorConfig.network.webrtc_config = { iceServers: iceUrls.map((url) => ({ urls: [url] })) };
 
     console.log('Writing conductor-config.yaml...');
 


### PR DESCRIPTION
The previous [commit](https://github.com/lightningrodlabs/moss/commit/94cee99590328dd9b2a61d82883e4c2db0bf4792) introduced the change to using the conductor config from a template.