### PR TITLE
Fix: Don't write other agent's StewardPermissionClaim to own source chain

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -5,13 +5,12 @@
   "scripts": {
     "test": "vitest run",
     "test:group": "vitest --dir ./src/group/group run",
-    "test:assets": "vitest --dir ./src/assets/assets run",
-    "test:stewards": "vitest ./src/group/group/steward_permissions.test.ts run"
+    "test:assets": "vitest --dir ./src/assets/assets run"
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.8.0",
     "@holochain/client": "^0.19.1",
-    "@holochain/tryorama": "0.18.0-rc.1",
+    "@holochain/tryorama": "^0.18.2",
     "@holochain-open-dev/utils": "^0.500.2",
     "@theweave/group-client": "^0.4.0",
     "@theweave/api": "^0.5.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "vitest run",
     "test:group": "vitest --dir ./src/group/group run",
-    "test:assets": "vitest --dir ./src/assets/assets run"
+    "test:assets": "vitest --dir ./src/assets/assets run",
+    "test:stewards": "vitest ./src/group/group/steward_permissions.test.ts run"
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.8.0",

--- a/tests/src/group/group/steward_permissions.test.ts
+++ b/tests/src/group/group/steward_permissions.test.ts
@@ -221,6 +221,8 @@ test('get_my_permission_type returns the correct result after getting permission
     // Set up the app to be installed
     const appSource = { appBundleSource };
 
+    console.log('Starting conductors');
+
     const [
       [progenitor, progenitorPubKey],
       [steward, stewardPubKey, stewardPermissionHash],
@@ -240,7 +242,6 @@ test('get_my_permission_type returns the correct result after getting permission
       fn_name: 'get_my_permission_type',
       payload: { input: null },
     });
-    console.log('Got my permission type before: ', myPermissionTypeBefore);
     assert(myPermissionTypeBefore.type === 'Member');
 
     // Normal member gets permission type of steward
@@ -256,7 +257,6 @@ test('get_my_permission_type returns the correct result after getting permission
       fn_name: 'get_my_permission_type',
       payload: { input: null },
     });
-    console.log('Got my permission type after: ', myPermissionTypeAfter);
     assert(myPermissionTypeAfter.type === 'Member');
   });
 });

--- a/tests/src/shared.ts
+++ b/tests/src/shared.ts
@@ -1,7 +1,6 @@
-import { AnyDhtHash, DnaHash } from '@holochain/client';
-import { CallableCell, Player } from '@holochain/tryorama';
+import { CallableCell, PlayerApp } from '@holochain/tryorama';
 
-export function getCellByRoleName(player: Player, roleName: string): CallableCell {
+export function getCellByRoleName(player: PlayerApp, roleName: string): CallableCell {
   const cells = player.cells;
   return cells.find((cell) => cell.name === roleName);
 }

--- a/tests/src/shared.ts
+++ b/tests/src/shared.ts
@@ -7,3 +7,4 @@ export function getCellByRoleName(player: Player, roleName: string): CallableCel
 }
 
 export const GROUP_HAPP_PATH = process.cwd() + '/../workdir/group.happ';
+// export const GROUP_HAPP_PATH = process.cwd() + '/../resources/default-apps/group.happ';

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,9 +1,8 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     threads: false,
-    testTimeout: 60*1000*3 // 3  mins
+    testTimeout: 60 * 1_000 * 3, // 3  mins
   },
-})
-
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,7 +1659,7 @@
   resolved "https://registry.yarnpkg.com/@holochain-playground/cli/-/cli-0.1.1.tgz#a5deb207dd3362cf7ab45070f0bc3cb8f12d9602"
   integrity sha512-JbapAe+uBaec52rTePjdlP0mq3zQhJG/hrdbCd+eecZLA3cXWEGgISR5YwLtx6udN+0ghCDH4U6KILjPiwWZMg==
 
-"@holochain/client@0.19.0", "@holochain/client@^0.19.0", "@holochain/client@^0.19.0-rc.0":
+"@holochain/client@0.19.0", "@holochain/client@^0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@holochain/client/-/client-0.19.0.tgz#5bf3cf9ef58f2da9a060b31160daf197cfaf2346"
   integrity sha512-LAiuQwyAQlLJp5Y0uT7EKuWy2AoCxMLdTECCLOs8ALADZzhNykFi2rmeC9hzskPXMR441bOhHPBWynqzQH95Ew==
@@ -1689,16 +1689,16 @@
     lodash-es "^4.17.21"
     ws "^8.14.2"
 
-"@holochain/tryorama@0.18.0-rc.1":
-  version "0.18.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@holochain/tryorama/-/tryorama-0.18.0-rc.1.tgz#fe56224d2cc1663bbc567d0e00291f651a502fa7"
-  integrity sha512-uZFpDWor701JmFHPbJ3or7+nfmTKzdIJR2uLq6aB1oSWSeXrKZHC27/sRaSWVWQnWL2gRrbZtDgbTHAvTTS8RQ==
+"@holochain/tryorama@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@holochain/tryorama/-/tryorama-0.18.2.tgz#5afc35ebbb3a2a75e793924f140607594806180d"
+  integrity sha512-6LfttoYm2kZ4Qqb64jkJGcsXdkn9rsAs1mjrsbcSiwNz+M8CFuX4lHX2Usyf6S2QMhpkA7hzqm5pG8CGS54aqQ==
   dependencies:
-    "@holochain/client" "^0.19.0-rc.0"
-    get-port "^6.1.2"
+    "@holochain/client" "^0.19.0"
+    get-port "^7.0.0"
     js-yaml "^4.1.0"
     lodash "^4.17.21"
-    uuid "^8.3.2"
+    uuid "^11.0.0"
     winston "^3.8.2"
     ws "^8.11.0"
 
@@ -3188,7 +3188,7 @@
     defer-to-connect "^2.0.0"
 
 "@theweave/api@file:libs/api":
-  version "0.5.0"
+  version "0.5.1"
   dependencies:
     "@holochain-open-dev/profiles" "^0.501.2"
     "@holochain/client" "^0.19.1"
@@ -3231,7 +3231,7 @@
     winston "3.11.0"
 
 "@theweave/elements@file:libs/elements":
-  version "0.5.0"
+  version "0.5.1"
   dependencies:
     "@holochain-open-dev/elements" "^0.500.1"
     "@holochain-open-dev/profiles" "^0.501.2"
@@ -3242,7 +3242,7 @@
     "@lit/localize" "^0.12.0"
     "@mdi/js" "^7.2.0"
     "@shoelace-style/shoelace" "^2.19.0"
-    "@theweave/api" "^0.5.0"
+    "@theweave/api" "^0.5.1"
     js-base64 "^3.7.5"
     lit "^3.0.2"
 
@@ -7705,10 +7705,10 @@ get-port@7.0.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-7.0.0.tgz#ffcd83da826146529e307a341d7801cae351daff"
   integrity sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==
 
-get-port@^6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
-  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
+get-port@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-7.1.0.tgz#d5a500ebfc7aa705294ec2b83cc38c5d0e364fec"
+  integrity sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==
 
 get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"
@@ -13235,6 +13235,11 @@ uuid@9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uuid@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
This PR fixes a bug and adds a regression test that other agent's StewardPermissionClaims don't get added to one's own source chain. It also now filters as an additional safety net that permission claims queried from the source chain are filtered by claims that relate to one's own agent key.