### PR TITLE
feat: Allow to send remote signals to specific agents only

### DIFF
--- a/iframes/applet-iframe/src/index.ts
+++ b/iframes/applet-iframe/src/index.ts
@@ -1,6 +1,7 @@
 import { ProfilesClient } from '@holochain-open-dev/profiles';
 import { EntryHashMap, HoloHashMap, parseHrl } from '@holochain-open-dev/utils';
 import {
+  AgentPubKey,
   AgentPubKeyB64,
   AppAuthenticationToken,
   AppClient,
@@ -310,10 +311,11 @@ const weaveApi: WeaveServices = {
       type: 'applet-participants',
     }),
 
-  sendRemoteSignal: (payload: Uint8Array) =>
+  sendRemoteSignal: (payload: Uint8Array, toAgents?: AgentPubKey[]) =>
     postMessage({
       type: 'send-remote-signal',
       payload,
+      toAgents,
     }),
 
   onRemoteSignal: (callback: (payload: Uint8Array) => any) => {

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theweave/api",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "license": "MIT",

--- a/libs/api/src/api.ts
+++ b/libs/api/src/api.ts
@@ -420,9 +420,11 @@ export interface WeaveServices {
    * that are currently online.
    *
    * @param payload Arbitrary payload, for example any msgpack encoded javascript object
+   * @param toAgents (optional) To which agents to send the signal. Default is all agents
+   * of the group in which this instance of the Tool is installed in.
    * @returns
    */
-  sendRemoteSignal: (payload: Uint8Array) => Promise<void>;
+  sendRemoteSignal: (payload: Uint8Array, toAgents?: AgentPubKey[]) => Promise<void>;
   /**
    * Event listener allowing to register a callback that will get executed if a remote
    * signal that had been sent with `WeaveClient.sendRemoteSignal()` arrives.
@@ -543,7 +545,8 @@ export class WeaveClient implements WeaveServices {
 
   appletParticipants = () => window.__WEAVE_API__.appletParticipants();
 
-  sendRemoteSignal = (payload: Uint8Array) => window.__WEAVE_API__.sendRemoteSignal(payload);
+  sendRemoteSignal = (payload: Uint8Array, toAgents?: AgentPubKey[]) =>
+    window.__WEAVE_API__.sendRemoteSignal(payload, toAgents);
 
   onRemoteSignal = (callback: (payload: Uint8Array) => any) =>
     window.__WEAVE_API__.onRemoteSignal(callback);

--- a/libs/api/src/types.ts
+++ b/libs/api/src/types.ts
@@ -415,6 +415,7 @@ export type AppletToParentRequest =
   | {
       type: 'send-remote-signal';
       payload: Uint8Array;
+      toAgents?: AgentPubKey[];
     }
   | {
       type: 'create-clone-cell';

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -611,13 +611,20 @@ export async function handleAppletIframeMessage(
         Array.from(groupStores.values()).map(async (store) => {
           const peerStatuses = get(store.peerStatuses());
           if (peerStatuses) {
-            const peersToSendSignal = Object.entries(peerStatuses)
+            let peersToSendSignal = Object.entries(peerStatuses)
               .filter(
                 ([pubkeyB64, status]) =>
                   status.status !== 'offline' &&
                   pubkeyB64 !== encodeHashToBase64(store.groupClient.myPubKey),
               )
               .map(([pubkeyB64, _]) => decodeHashFromBase64(pubkeyB64));
+
+            if (message.toAgents) {
+              const toAgents = message.toAgents.map((a) => encodeHashToBase64(a));
+              peersToSendSignal = peersToSendSignal.filter((agent) =>
+                toAgents.includes(encodeHashToBase64(agent)),
+              );
+            }
 
             await store.groupClient.remoteSignalArbitrary(remoteSignalPayload, peersToSendSignal);
           }

--- a/src/renderer/src/validationSchemas.ts
+++ b/src/renderer/src/validationSchemas.ts
@@ -358,6 +358,7 @@ export const AppletToParentRequest = Type.Union([
     {
       type: Type.Literal('send-remote-signal'),
       payload: Type.Uint8Array(),
+      toAgents: Type.Optional(Type.Array(Type.Uint8Array())),
     },
     { additionalProperties: false },
   ),


### PR DESCRIPTION
Adds the option to the Weave API to send remote signals to specific agents only.