### PR TITLE
fix: Retry installation of group happ once if it fails

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1259,7 +1259,7 @@ if (!RUNNING_WITH_COMMAND) {
     ipcMain.handle('lair-setup-required', (): boolean => {
       return !WE_FILE_SYSTEM.keystoreInitialized();
     });
-    ipcMain.handle('create-group', async (_e, withProgenitor: boolean): Promise<AppInfo> => {
+    ipcMain.handle('install-group-happ', async (_e, withProgenitor: boolean): Promise<AppInfo> => {
       const apps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
       let agentPubKey = globalPubKeyFromListAppsResponse(apps);
       if (!agentPubKey) {
@@ -1280,25 +1280,54 @@ if (!RUNNING_WITH_COMMAND) {
         ? { progenitor: encodeHashToBase64(agentPubKey) }
         : { progenitor: null };
 
-      const appInfo = await HOLOCHAIN_MANAGER!.adminWebsocket.installApp({
-        source: {
-          type: 'path',
-          value: groupHappPath,
-        },
-        installed_app_id: appId,
-        agent_key: agentPubKey,
-        network_seed: networkSeed,
-        roles_settings: {
-          group: {
-            type: 'provisioned',
-            value: {
-              modifiers: {
-                properties,
+      let appInfo: AppInfo;
+
+      // Try installing the app twice. It may fail the first time with a timeout error
+      // if wasms take too long to compile. This should only happen the very first time
+      // a group happ is being installed.
+      try {
+        appInfo = await HOLOCHAIN_MANAGER!.adminWebsocket.installApp({
+          source: {
+            type: 'path',
+            value: groupHappPath,
+          },
+          installed_app_id: appId,
+          agent_key: agentPubKey,
+          network_seed: networkSeed,
+          roles_settings: {
+            group: {
+              type: 'provisioned',
+              value: {
+                modifiers: {
+                  properties,
+                },
               },
             },
           },
-        },
-      });
+        });
+      } catch (e) {
+        console.warn('Failed to install group happ: ', e, '\nRetrying once...');
+        WE_EMITTER.emitMossError(`Failed to install group happ: ${e}.\n Retrying once...`);
+        appInfo = await HOLOCHAIN_MANAGER!.adminWebsocket.installApp({
+          source: {
+            type: 'path',
+            value: groupHappPath,
+          },
+          installed_app_id: appId,
+          agent_key: agentPubKey,
+          network_seed: networkSeed,
+          roles_settings: {
+            group: {
+              type: 'provisioned',
+              value: {
+                modifiers: {
+                  properties,
+                },
+              },
+            },
+          },
+        });
+      }
       await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
       return appInfo;
     });

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -109,7 +109,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   isMainWindowFocused: () => ipcRenderer.invoke('is-main-window-focused'),
   joinGroup: (networkSeed: string, progenitor: AgentPubKeyB64 | undefined) =>
     ipcRenderer.invoke('join-group', networkSeed, progenitor),
-  createGroup: (useProgenitor: boolean) => ipcRenderer.invoke('create-group', useProgenitor),
+  installGroupHapp: (useProgenitor: boolean) =>
+    ipcRenderer.invoke('install-group-happ', useProgenitor),
   notification: (
     notification: FrameNotification,
     showInSystray: boolean,

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -131,7 +131,7 @@ declare global {
       isMainWindowFocused: () => Promise<boolean | undefined>;
       isDevModeEnabled: () => Promise<boolean>;
       joinGroup: (networkSeed: string, progenitor: AgentPubKeyB64 | null) => Promise<AppInfo>;
-      createGroup: (useProgenitor: boolean) => Promise<AppInfo>;
+      installGroupHapp: (useProgenitor: boolean) => Promise<AppInfo>;
       notification: (
         notification: FrameNotification,
         showInSystray: boolean,
@@ -195,8 +195,8 @@ export async function joinGroup(
   return window.electronAPI.joinGroup(networkSeed, progenitor);
 }
 
-export async function createGroup(useProgenitor: boolean): Promise<AppInfo> {
-  return window.electronAPI.createGroup(useProgenitor);
+export async function installGroupHapp(useProgenitor: boolean): Promise<AppInfo> {
+  return window.electronAPI.installGroupHapp(useProgenitor);
 }
 
 export async function dialogMessagebox(

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -56,11 +56,11 @@ import { GroupStore } from './groups/group-store.js';
 import { DnaLocation, HrlLocation, locateHrl } from './processes/hrl/locate-hrl.js';
 import {
   ConductorInfo,
-  createGroup,
   getAllAppAssetsInfos,
   getAppletDevPort,
   getGroupProfile,
   getToolIcon,
+  installGroupHapp,
   joinGroup,
   storeGroupProfile,
 } from './electron-api.js';
@@ -802,7 +802,7 @@ export class MossStore {
   public async createGroup(name: string, logo: string, useProgenitor: boolean): Promise<AppInfo> {
     if (!logo) throw new Error('No logo provided.');
 
-    const appInfo = await createGroup(useProgenitor);
+    const appInfo = await installGroupHapp(useProgenitor);
 
     await this.reloadManualStores();
 


### PR DESCRIPTION
Installing a group happ the first time can time out (see issue https://github.com/holochain/holochain/issues/5058). This PR makes us retry installing it once to catch the case where it's such a timeout since in that case it typically works the second time.

Also renames the associated IPC call to 'install-group-happ' for more clarity.