### PR TITLE
feat: pre-populate profile with previously used profile

### DIFF
--- a/src/renderer/src/elements/_new_design/profile/moss-create-profile.ts
+++ b/src/renderer/src/elements/_new_design/profile/moss-create-profile.ts
@@ -54,7 +54,7 @@ export class MossCreateProfile extends LitElement {
     try {
       await this.profileStore.client.createProfile(profile);
       // We persist the profile in localStorage as the default profile
-      // to use pre-populate the profile next time a new profile needs to
+      // to pre-populate the profile next time a new profile needs to
       // be created
       this.mossStore.persistedStore.personas.set([profile]);
       this.dispatchEvent(

--- a/src/renderer/src/elements/_new_design/profile/moss-edit-profile.ts
+++ b/src/renderer/src/elements/_new_design/profile/moss-edit-profile.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit';
+import { html, LitElement, PropertyValueMap } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { localized, msg, str } from '@lit/localize';
 import { consume } from '@lit/context';
@@ -74,6 +74,16 @@ export class MossEditProfile extends LitElement {
     if (this.profile) {
       this.nickname = this.profile.nickname;
       this.avatar = this.profile.fields.avatar;
+    }
+  }
+
+  async willUpdate(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
+    if (changedProperties.has('profile')) {
+      if (this.profile) {
+        this.checkDisabled(); // We want to enable the button now if the profile had been set in the parent component
+        this.nickname = this.profile.nickname;
+        this.avatar = this.profile.fields.avatar;
+      }
     }
   }
 

--- a/src/renderer/src/persisted-store.ts
+++ b/src/renderer/src/persisted-store.ts
@@ -3,6 +3,7 @@ import { AppletId, FrameNotification } from '@theweave/api';
 import { AppletNotificationSettings } from './applets/types';
 import { destringifyAndDecode, encodeAndStringify } from './utils';
 import { WalInPocket } from './moss-store';
+import { Profile } from '@holochain-open-dev/profiles';
 
 /**
  * A store that's persisted.
@@ -26,6 +27,16 @@ export class PersistedStore {
     },
     set: (value) => {
       this.store.setItem<string[]>('declinedMossUpdates', value);
+    },
+  };
+
+  personas: SubStore<Profile[], Profile[], []> = {
+    value: () => {
+      const personas = this.store.getItem<Profile[]>('personas');
+      return personas ? personas : [];
+    },
+    set: (value) => {
+      this.store.setItem<Profile[]>('personas', value);
     },
   };
 


### PR DESCRIPTION
Persists the profile in localStorage if created upon creating or joining a group such that it can be used to pre-populate the profile prompt next time a group is created or being joined.