### PR TITLE
fix: clean up product name and duplicate 'ago' suffix

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: org.lightningrodlabs.moss-0.15
-productName: Moss (0.15)
+productName: Moss
 directories:
   buildResources: build
 files:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -364,6 +364,10 @@ if (!RUNNING_WITH_COMMAND) {
     RUN_OPTIONS.devInfo ? RUN_OPTIONS.devInfo.tempDir : undefined,
   );
 
+  // Set the display name after filesystem paths are established so the storage directory
+  // continues to derive from package.json's `name` field rather than the display name.
+  app.setName(process.env.NODE_ENV === 'development' ? 'Moss-dev' : 'Moss');
+
   const APPLET_IFRAME_SCRIPT = fs.readFileSync(
     path.resolve(__dirname, '../applet-iframe/index.mjs'),
     'utf-8',

--- a/src/renderer/src/personal-views/welcome-view/elements/notification-card.ts
+++ b/src/renderer/src/personal-views/welcome-view/elements/notification-card.ts
@@ -265,7 +265,7 @@ export class NotificationCard extends LitElement {
             <div class="notification-date">
               ${this.notification
             ? this.timeAgo.format(new Date(this.notification.timestamp), 'twitter')
-            : 'unknown date'} ago
+            : 'unknown date'}
             </div>
             <div class="notification-buttons">
               ${aboutWal ? html`


### PR DESCRIPTION
Remove version suffix from electron-builder productName, set display name via app.setName() after filesystem paths are established, and remove redundant 'ago' text already included by timeAgo twitter format.