### PR TITLE
Testing fixes.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,12 +103,11 @@ jobs:
         run: |
           nix develop --command yarn test
 
-      - name: Run tryorama tests
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          export PATH="$PATH:$GITHUB_WORKSPACE/resources/bins"
-          echo $PATH
-          yarn test
+#      - name: Run tryorama tests
+#        if: matrix.platform == 'ubuntu-22.04'
+#        run: |
+#          export PATH="$PATH:$GITHUB_WORKSPACE/resources/bins"
+#          yarn test
 
       - name: Build cli
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,8 @@ jobs:
       - name: Run tryorama tests
         if: matrix.platform == 'ubuntu-22.04'
         run: |
+          export PATH="$PATH:$GITHUB_WORKSPACE/resources/bins"
+          echo $PATH
           yarn test
 
       - name: Build cli

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,17 @@ jobs:
       - name: Build example-applet
         if: matrix.platform == 'ubuntu-22.04'
         run: |
-          yarn workspace example-applet package     
+          yarn workspace example-applet package
+
+      - name: Build group.happ from source
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          yarn build:group-happ
+
+      - name: Run tryorama tests
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          yarn test
 
       - name: Build cli
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,10 +85,23 @@ jobs:
         run: |
           yarn build:group-happ
 
+      - name: Install nix
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: cachix/install-nix-action@v25
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Setup holochain-ci cachix
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: cachix/cachix-action@v15
+        with:
+          name: holochain-ci
+
       - name: Run tryorama tests
         if: matrix.platform == 'ubuntu-22.04'
         run: |
-          yarn test
+          nix develop --command yarn test
 
       - name: Build cli
         if: matrix.platform == 'ubuntu-22.04'

--- a/scripts/fetch-hc.mjs
+++ b/scripts/fetch-hc.mjs
@@ -1,3 +1,8 @@
 import {downloadHolochainBinary} from './fetch-fns.mjs';
+import fs from "fs";
 
 downloadHolochainBinary("hc", false);
+
+const mossConfig = JSON.parse(fs.readFileSync('moss.config.json', 'utf-8'));
+const bootstrapSrvVersion = mossConfig.kitsune2BootstrapSrv ?? null;
+downloadHolochainBinary("kitsune2-bootstrap-srv", false, bootstrapSrvVersion);

--- a/scripts/fetch-hc.mjs
+++ b/scripts/fetch-hc.mjs
@@ -1,8 +1,8 @@
 import {downloadHolochainBinary} from './fetch-fns.mjs';
-import fs from "fs";
 
 downloadHolochainBinary("hc", false);
 
-const mossConfig = JSON.parse(fs.readFileSync('moss.config.json', 'utf-8'));
-const bootstrapSrvVersion = mossConfig.kitsune2BootstrapSrv ?? null;
-downloadHolochainBinary("kitsune2-bootstrap-srv", false, bootstrapSrvVersion);
+//import fs from "fs";
+// const mossConfig = JSON.parse(fs.readFileSync('moss.config.json', 'utf-8'));
+// const bootstrapSrvVersion = mossConfig.kitsune2BootstrapSrv ?? null;
+// downloadHolochainBinary("kitsune2-bootstrap-srv", false, bootstrapSrvVersion);

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@msgpack/msgpack": "^2.8.0",
     "@holochain/client": "=0.20.4-rc.0",
-    "@holochain/tryorama": "^0.19.0",
+    "@holochain/tryorama": "^0.19.1",
     "@holochain-open-dev/utils": "^0.601.0",
     "@theweave/group-client": "^0.5.2",
     "@theweave/api": "^0.6.4",

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "vitest run",
+    "test:one": "vitest --reporter=verbose -t 'Create expiring steward permission and retrieve it in different ways'",
     "test:group": "vitest --dir ./src/group/group run",
     "test:assets": "vitest --dir ./src/assets/assets run"
   },

--- a/tests/src/assets/assets/relations.test.ts
+++ b/tests/src/assets/assets/relations.test.ts
@@ -14,7 +14,6 @@ import {
 
 test('Add an asset relation, remove it again and try to get it from the ALL_ASSET_RELATIONS_ANCHOR', async () => {
   await runScenario(async (scenario) => {
-    console.log('Hello!');
     // Construct proper paths for your app.
     // This assumes app bundle created by the `hc app pack` command.
     const testAppPath = GROUP_HAPP_PATH;

--- a/tests/src/group/group/common.ts
+++ b/tests/src/group/group/common.ts
@@ -13,133 +13,148 @@ import {
   PlayerApp,
   Scenario,
 } from '@holochain/tryorama';
-//import { Accountability, StewardPermission } from '@theweave/group-client';
-//import { getCellByRoleName } from '../../shared';
-//
-// export async function threeAgentsOneProgenitorOneStewardOneMember(
-//   scenario: Scenario,
-//   appBundleSource: AppBundleSource,
-//   roleNames: RoleName[],
-//   expiry?: number,
-// ): Promise<
-//   [[PlayerApp, AgentPubKey], [PlayerApp, AgentPubKey, ActionHash], [PlayerApp, AgentPubKey]]
-// > {
-//   console.log('@threeAgentsOneProgenitorOneStewardOneMember: calling nAgentsOneProgenitor...');
-//
-//   const [[alice, alicePubKey], [bob, bobPubKey], [neitherBobNorAlice, neitherBobNorAlicePubKey]] =
-//     await nAgentsOneProgenitor(scenario, appBundleSource, roleNames, 3);
-//
-//   const groupCellAlice = getCellByRoleName(alice, 'group');
-//
-//   const input: StewardPermission = {
-//     for_agent: bobPubKey,
-//     expiry,
-//   };
-//   await groupCellAlice.callZome({
-//     zome_name: 'group',
-//     fn_name: 'create_steward_permission',
-//     payload: input,
-//   });
-//
-//   const permissionType: Accountability = await groupCellAlice.callZome({
-//     zome_name: 'group',
-//     fn_name: 'get_agent_permission_type',
-//     payload: { input: bobPubKey },
-//   });
-//
-//   if (permissionType.type !== 'Steward') {
-//     const now = Date.now() * 1000;
-//     throw new Error(
-//       `Bob should have steward permission at this point but got permission: ${JSON.stringify(permissionType)}.\nExpiry (us): ${expiry}\nTime now (us): ${now}\nTime left until expiry: ${expiry - now}`,
-//     );
-//   }
-//
-//   console.log('@threeAgentsOneProgenitorOneStewardOneMember: awaiting dht sync...');
-//
-//   // Wait for dht sync to make sure that Bob has access to his permission
-//   await dhtSync([alice, bob, neitherBobNorAlice], groupCellAlice.cell_id[0], undefined, 10_000);
-//
-//   return [
-//     [alice, alicePubKey],
-//     [bob, bobPubKey, permissionType.content.permission_hash],
-//     [neitherBobNorAlice, neitherBobNorAlicePubKey],
-//   ];
-// }
-//
-// export async function twoAgentsOneProgenitorAndOneSteward(
-//   scenario: Scenario,
-//   appBundleSource: AppBundleSource,
-//   roleNames: RoleName[],
-//   expiry?: number,
-// ): Promise<[[PlayerApp, AgentPubKey], [PlayerApp, AgentPubKey, ActionHash]]> {
-//   const [[alice, alicePubKey], [bob, bobPubKey]] = await nAgentsOneProgenitor(
-//     scenario,
-//     appBundleSource,
-//     roleNames,
-//     2,
-//   );
-//   const groupCellAlice = getCellByRoleName(alice, 'group');
-//
-//   const input: StewardPermission = {
-//     for_agent: bobPubKey,
-//     expiry,
-//   };
-//   await groupCellAlice.callZome({
-//     zome_name: 'group',
-//     fn_name: 'create_steward_permission',
-//     payload: input,
-//   });
-//
-//   const permissionType: PermissionType = await groupCellAlice.callZome({
-//     zome_name: 'group',
-//     fn_name: 'get_agent_permission_type',
-//     payload: { input: bobPubKey },
-//   });
-//
-//   if (permissionType.type !== 'Steward') {
-//     const now = Date.now() * 1000;
-//     throw new Error(
-//       `Bob should have steward permission at this point but got permission: ${JSON.stringify(permissionType)}.\nExpiry (us): ${expiry}\nTime now (us): ${now}\nTime left until expiry: ${expiry - now}`,
-//     );
-//   }
-//
-//   // Wait for dht sync to make sure that Bob has access to his permission
-//   await dhtSync([alice, bob], groupCellAlice.cell_id[0]);
-//
-//   return [
-//     [alice, alicePubKey],
-//     [bob, bobPubKey, permissionType.content.permission_hash],
-//   ];
-// }
-//
-// export async function nAgentsOneProgenitor(
-//   scenario: Scenario,
-//   appBundleSource: AppBundleSource,
-//   roleNames: RoleName[],
-//   nAgents: number,
-// ): Promise<[PlayerApp, AgentPubKey][]> {
-//   const [alice, alicePubKey] = await installAppWithProgenitor(
-//     scenario,
-//     appBundleSource,
-//     roleNames,
-//     true,
-//   );
-//
-//   const allAgents: [PlayerApp, AgentPubKey][] = [[alice, alicePubKey]];
-//
-//   for (let i = 0; i < nAgents; i++) {
-//     const [player, playerPubKey] = await installAppWithProgenitor(
-//       scenario,
-//       appBundleSource,
-//       roleNames,
-//       true,
-//       alicePubKey,
-//     );
-//     allAgents.push([player, playerPubKey]);
-//   }
-//
-//   return allAgents;
-// }
+import { Accountability, StewardPermission } from '@theweave/group-client';
+import { getCellByRoleName } from '../../shared.js';
+
+/**
+ * Spin up `nAgents` players sharing a single group, with the first agent as the
+ * progenitor. The progenitor's pubkey is used as the `progenitor` DNA property
+ * for everyone, so all agents land in the same group.
+ */
+export async function nAgentsOneProgenitor(
+  scenario: Scenario,
+  appBundleSource: AppBundleSource,
+  roleNames: RoleName[],
+  nAgents: number,
+): Promise<[PlayerApp, AgentPubKey][]> {
+  const [alice, alicePubKey] = await installAppWithProgenitor(
+    scenario,
+    appBundleSource,
+    roleNames,
+    true,
+  );
+
+  const allAgents: [PlayerApp, AgentPubKey][] = [[alice, alicePubKey]];
+
+  for (let i = 0; i < nAgents - 1; i++) {
+    const [player, playerPubKey] = await installAppWithProgenitor(
+      scenario,
+      appBundleSource,
+      roleNames,
+      true,
+      alicePubKey,
+    );
+    allAgents.push([player, playerPubKey]);
+  }
+
+  return allAgents;
+}
+
+/**
+ * Set up a group with Alice as progenitor and Bob as steward. Alice issues Bob a
+ * `StewardPermission` (optionally expiring at `expiry`, microseconds since epoch),
+ * then waits for DHT sync so Bob can see his permission.
+ *
+ * Returns [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]].
+ */
+export async function twoAgentsOneProgenitorAndOneSteward(
+  scenario: Scenario,
+  appBundleSource: AppBundleSource,
+  roleNames: RoleName[],
+  expiry?: number,
+): Promise<[[PlayerApp, AgentPubKey], [PlayerApp, AgentPubKey, ActionHash]]> {
+  const [[alice, alicePubKey], [bob, bobPubKey]] = await nAgentsOneProgenitor(
+    scenario,
+    appBundleSource,
+    roleNames,
+    2,
+  );
+  const groupCellAlice = getCellByRoleName(alice, 'group');
+
+  const input: StewardPermission = {
+    for_agent: bobPubKey,
+    expiry,
+  };
+  await groupCellAlice.callZome({
+    zome_name: 'group',
+    fn_name: 'create_steward_permission',
+    payload: input,
+  });
+
+  const accs: Accountability[] = await groupCellAlice.callZome({
+    zome_name: 'group',
+    fn_name: 'get_agent_accountabilities',
+    payload: { input: [bobPubKey, Date.now() * 1000], local: true },
+  });
+
+  const stewardAcc = accs.find((a) => a.type === 'Steward');
+  if (!stewardAcc || stewardAcc.type !== 'Steward') {
+    const now = Date.now() * 1000;
+    throw new Error(
+      `Bob should have a Steward accountability immediately after issuance. Got: ${JSON.stringify(accs)}.\nExpiry (us): ${expiry}\nTime now (us): ${now}\nTime left until expiry: ${expiry === undefined ? 'never' : expiry - now}`,
+    );
+  }
+
+  // Wait for dht sync so Bob can see his own permission via the DHT.
+  await dhtSync([alice, bob], groupCellAlice.cell_id[0]);
+
+  return [
+    [alice, alicePubKey],
+    [bob, bobPubKey, stewardAcc.content.permission_hash],
+  ];
+}
+
+/**
+ * Set up a group with Alice as progenitor, Bob as steward, and Charlie as a plain
+ * member. Same flow as `twoAgentsOneProgenitorAndOneSteward` but with a third
+ * non-privileged agent in the same group, useful for testing how queries by a
+ * non-privileged agent affect that agent's own accountabilities.
+ */
+export async function threeAgentsOneProgenitorOneStewardOneMember(
+  scenario: Scenario,
+  appBundleSource: AppBundleSource,
+  roleNames: RoleName[],
+  expiry?: number,
+): Promise<
+  [[PlayerApp, AgentPubKey], [PlayerApp, AgentPubKey, ActionHash], [PlayerApp, AgentPubKey]]
+> {
+  const [[alice, alicePubKey], [bob, bobPubKey], [charlie, charliePubKey]] =
+    await nAgentsOneProgenitor(scenario, appBundleSource, roleNames, 3);
+
+  const groupCellAlice = getCellByRoleName(alice, 'group');
+
+  const input: StewardPermission = {
+    for_agent: bobPubKey,
+    expiry,
+  };
+  await groupCellAlice.callZome({
+    zome_name: 'group',
+    fn_name: 'create_steward_permission',
+    payload: input,
+  });
+
+  const accs: Accountability[] = await groupCellAlice.callZome({
+    zome_name: 'group',
+    fn_name: 'get_agent_accountabilities',
+    payload: { input: [bobPubKey, Date.now() * 1000], local: true },
+  });
+  const stewardAcc = accs.find((a) => a.type === 'Steward');
+  if (!stewardAcc || stewardAcc.type !== 'Steward') {
+    const now = Date.now() * 1000;
+    throw new Error(
+      `Bob should have a Steward accountability immediately after issuance. Got: ${JSON.stringify(accs)}.\nExpiry (us): ${expiry}\nTime now (us): ${now}\nTime left until expiry: ${expiry === undefined ? 'never' : expiry - now}`,
+    );
+  }
+
+  // Generous timeout: three-way DHT sync over a tryorama localnet is occasionally slow.
+  await dhtSync([alice, bob, charlie], groupCellAlice.cell_id[0], undefined, 30_000);
+
+  return [
+    [alice, alicePubKey],
+    [bob, bobPubKey, stewardAcc.content.permission_hash],
+    [charlie, charliePubKey],
+  ];
+}
 
 /**
  *

--- a/tests/src/group/group/steward_permissions.test.ts
+++ b/tests/src/group/group/steward_permissions.test.ts
@@ -10,7 +10,6 @@ import {
 
 import { getCellByRoleName, GROUP_HAPP_PATH } from '../../shared.js';
 import {
-  sleep,
   threeAgentsOneProgenitorOneStewardOneMember,
   twoAgentsOneProgenitorAndOneSteward,
 } from './common.js';
@@ -163,7 +162,7 @@ test('Create expiring steward permission and retrieve it in different ways', asy
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Alice's query of Bob: no longer Steward (empty array since Member is implicit).
+    // At expiry: Bob should still be Steward
     let bobAccsAfter: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
       fn_name: 'get_agent_accountabilities',
@@ -172,13 +171,18 @@ test('Create expiring steward permission and retrieve it in different ways', asy
     assert(bobAccsAfter.some((a) => a.type === 'Steward'));
     assert(!bobAccsAfter.some((a) => a.type === 'Progenitor'));
 
-    // Alice's query of Bob: no longer Steward (empty array since Member is implicit).
+    // At expiry + 1: Bob should no longer be Steward (empty array since Member is implicit).
     bobAccsAfter = await groupCellAlice.callZome({
       zome_name: 'group',
       fn_name: 'get_agent_accountabilities',
       payload: { input: [bobPubKey, now_101], local: true },
     });
     assert(bobAccsAfter.length == 0);
+    assert.equal(
+      bobAccsAfter.length,
+      0,
+      `Bob should have no accountabilities, got: ${JSON.stringify(bobAccsAfter)}`,
+    );
 
     // Bob's query of himself: also no longer Steward.
     const bobMyAccsAfter: Accountability[] = await groupCellBob.callZome({
@@ -186,7 +190,11 @@ test('Create expiring steward permission and retrieve it in different ways', asy
       fn_name: 'get_my_accountabilities',
       payload: { input: now_101, local: false },
     });
-    assert(bobMyAccsAfter.length == 0);
+    assert.equal(
+      bobMyAccsAfter.length,
+      0,
+      `Bob should have no accountabilities, got: ${JSON.stringify(bobMyAccsAfter)}`,
+    );
   });
 });
 

--- a/tests/src/group/group/steward_permissions.test.ts
+++ b/tests/src/group/group/steward_permissions.test.ts
@@ -14,103 +14,99 @@ import {
   threeAgentsOneProgenitorOneStewardOneMember,
   twoAgentsOneProgenitorAndOneSteward,
 } from './common.js';
-import { PermissionType, StewardPermission } from '@theweave/group-client';
+import { Accountability, StewardPermission } from '@theweave/group-client';
 import { fail } from 'assert';
+
+// Helper: pull the Steward variant out of a `Vec<Accountability>` response and
+// fail loudly if there isn't exactly one.
+function expectStewardAccountability(accs: Accountability[]): Extract<
+  Accountability,
+  { type: 'Steward' }
+> {
+  const steward = accs.find((a): a is Extract<Accountability, { type: 'Steward' }> => a.type === 'Steward');
+  if (!steward) {
+    fail(`Expected a Steward accountability, got: ${JSON.stringify(accs)}`);
+  }
+  return steward;
+}
 
 test('Create unlimited steward permission and retrieve it in different ways', async () => {
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
 
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
-
     const [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
-      await twoAgentsOneProgenitorAndOneSteward(scenario, appSource.appBundleSource, ['group']);
+      await twoAgentsOneProgenitorAndOneSteward(scenario, appBundleSource, ['group']);
 
     const groupCellBob = getCellByRoleName(bob, 'group');
     const groupCellAlice = getCellByRoleName(alice, 'group');
 
-    // Check that Alice is progenitor
-    const permissionTypeAlice: PermissionType = await groupCellAlice.callZome({
+    // Alice (progenitor): get_my_accountabilities should include Progenitor.
+    const aliceMyAccs: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: true },
     });
+    assert(aliceMyAccs.some((a) => a.type === 'Progenitor'));
 
-    assert(permissionTypeAlice.type === 'Progenitor');
-
-    const permissionTypeAlice2: PermissionType = await groupCellAlice.callZome({
+    // Alice queries her own pubkey: same.
+    const aliceAgentAccs: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: alicePubKey },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [alicePubKey, Date.now() * 1000], local: true },
     });
+    assert(aliceAgentAccs.some((a) => a.type === 'Progenitor'));
 
-    assert(permissionTypeAlice2.type === 'Progenitor');
-
-    // Get permission type of Bob and verify that it's of type Steward and has no expiry
-    const permissionTypeBob: PermissionType = await groupCellAlice.callZome({
+    // Alice asks about Bob → Bob should be a Steward with the expected claim shape.
+    const bobAccsViaAlice: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: bobPubKey },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
     });
-
-    assert(permissionTypeBob.type === 'Steward');
+    const bobStewardViaAlice = expectStewardAccountability(bobAccsViaAlice);
     assert(
-      encodeHashToBase64(permissionTypeBob.content.permission.for_agent) ===
+      encodeHashToBase64(bobStewardViaAlice.content.permission.for_agent) ===
         encodeHashToBase64(bobPubKey),
     );
-    assert(!permissionTypeBob.content.permission.expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!permissionTypeBob.content.permission.permission_hash);
+    assert(!bobStewardViaAlice.content.permission.expiry);
+    // permission_hash on the inner StewardPermission is null for permissions issued by
+    // the progenitor (they aren't derived from a parent permission).
+    assert(!bobStewardViaAlice.content.permission.permission_hash);
     assert(
-      encodeHashToBase64(permissionTypeBob.content.permission_hash) ===
+      encodeHashToBase64(bobStewardViaAlice.content.permission_hash) ===
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Bob gets his own permission type
-    const permissionTypeBob2: PermissionType = await groupCellBob.callZome({
+    // Bob asks about himself → same Steward claim.
+    const bobMyAccs: Accountability[] = await groupCellBob.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
-
-    assert(permissionTypeBob2.type === 'Steward');
+    const bobMySteward = expectStewardAccountability(bobMyAccs);
     assert(
-      encodeHashToBase64(permissionTypeBob2.content.permission.for_agent) ===
+      encodeHashToBase64(bobMySteward.content.permission.for_agent) ===
         encodeHashToBase64(bobPubKey),
     );
-    assert(!permissionTypeBob2.content.permission.expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!permissionTypeBob2.content.permission.permission_hash);
+    assert(!bobMySteward.content.permission.expiry);
+    assert(!bobMySteward.content.permission.permission_hash);
     assert(
-      encodeHashToBase64(permissionTypeBob2.content.permission_hash) ===
+      encodeHashToBase64(bobMySteward.content.permission_hash) ===
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Get permission type of Bob and verify that it's of type Steward and has no expiry
-    const permissionTypeBob3: PermissionType = await groupCellAlice.callZome({
+    // Alice queries Bob a second time (now that Bob's claim has been seen at least once on
+    // the network) — should still report Steward.
+    const bobAccsViaAliceAgain: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: bobPubKey },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
     });
-
-    assert(permissionTypeBob3.type === 'Steward');
+    const bobStewardViaAliceAgain = expectStewardAccountability(bobAccsViaAliceAgain);
     assert(
-      encodeHashToBase64(permissionTypeBob3.content.permission.for_agent) ===
-        encodeHashToBase64(bobPubKey),
-    );
-    assert(!permissionTypeBob3.content.permission.expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!permissionTypeBob3.content.permission.permission_hash);
-    assert(
-      encodeHashToBase64(permissionTypeBob3.content.permission_hash) ===
+      encodeHashToBase64(bobStewardViaAliceAgain.content.permission_hash) ===
         encodeHashToBase64(bobPermissionHash),
     );
   });
@@ -118,178 +114,161 @@ test('Create unlimited steward permission and retrieve it in different ways', as
 
 test('Create expiring steward permission and retrieve it in different ways', async () => {
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
-
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
 
     const expiry = (Date.now() + 100_000) * 1_000;
 
     const [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
-      await twoAgentsOneProgenitorAndOneSteward(
-        scenario,
-        appSource.appBundleSource,
-        ['group'],
-        expiry,
-      );
+      await twoAgentsOneProgenitorAndOneSteward(scenario, appBundleSource, ['group'], expiry);
 
     const groupCellBob = getCellByRoleName(bob, 'group');
     const groupCellAlice = getCellByRoleName(alice, 'group');
 
-    // Get permission type of Bob and verify that it's of type Steward and has the correct expiry
-    const permissionTypeBob: PermissionType = await groupCellAlice.callZome({
+    // Alice queries Bob: Steward with the expected expiry.
+    const bobAccsBefore: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: bobPubKey },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
     });
-
-    assert(permissionTypeBob.type === 'Steward');
+    const bobStewardBefore = expectStewardAccountability(bobAccsBefore);
     assert(
-      encodeHashToBase64(permissionTypeBob.content.permission.for_agent) ===
+      encodeHashToBase64(bobStewardBefore.content.permission.for_agent) ===
         encodeHashToBase64(bobPubKey),
     );
-    assert.equal(permissionTypeBob.content.permission.expiry, expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!permissionTypeBob.content.permission.permission_hash);
+    assert.equal(bobStewardBefore.content.permission.expiry, expiry);
+    assert(!bobStewardBefore.content.permission.permission_hash);
     assert(
-      encodeHashToBase64(permissionTypeBob.content.permission_hash) ===
+      encodeHashToBase64(bobStewardBefore.content.permission_hash) ===
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Bob gets his own permission type
-    const permissionTypeBob2: PermissionType = await groupCellBob.callZome({
+    // Bob queries himself: same Steward claim.
+    const bobMyAccsBefore: Accountability[] = await groupCellBob.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
-
-    assert(permissionTypeBob2.type === 'Steward');
+    const bobMyStewardBefore = expectStewardAccountability(bobMyAccsBefore);
+    assert.equal(bobMyStewardBefore.content.permission.expiry, expiry);
     assert(
-      encodeHashToBase64(permissionTypeBob2.content.permission.for_agent) ===
-        encodeHashToBase64(bobPubKey),
-    );
-    assert.equal(permissionTypeBob2.content.permission.expiry, expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!permissionTypeBob2.content.permission.permission_hash);
-    assert(
-      encodeHashToBase64(permissionTypeBob2.content.permission_hash) ===
+      encodeHashToBase64(bobMyStewardBefore.content.permission_hash) ===
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Wait until expiry is over
+    // Wait until the permission expires.
     const timeUntilExpiry = expiry / 1000 - Date.now();
     await sleep(timeUntilExpiry);
 
-    // Alice gets permission type of Bob which should now be of type Member since the Steward permission has expired
-    const permissionTypeBob3: PermissionType = await groupCellAlice.callZome({
+    // Alice's query of Bob: no longer Steward (empty array since Member is implicit).
+    const bobAccsAfter: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: bobPubKey },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
     });
+    assert(!bobAccsAfter.some((a) => a.type === 'Steward'));
+    assert(!bobAccsAfter.some((a) => a.type === 'Progenitor'));
 
-    assert(permissionTypeBob3.type === 'Member');
-
-    // Bob gets his own permission type that should now be of type Member since the Steward permission has expired
-    const permissionTypeBob4: PermissionType = await groupCellBob.callZome({
+    // Bob's query of himself: also no longer Steward.
+    const bobMyAccsAfter: Accountability[] = await groupCellBob.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
-
-    assert(permissionTypeBob4.type === 'Member');
+    assert(!bobMyAccsAfter.some((a) => a.type === 'Steward'));
+    assert(!bobMyAccsAfter.some((a) => a.type === 'Progenitor'));
   });
 });
 
-test('get_my_permission_type returns the correct result after getting permission type of another agent with unlimited steward permission', async () => {
+test("get_my_accountabilities returns the correct result after querying another agent's accountabilities", async () => {
+  // Regression test for the privilege-escalation bug fixed in commit 48211967.
+  //
+  // Pre-fix, when a non-privileged agent (Charlie) called `is_agent_a_steward`
+  // for some other agent (Bob), the zome would unconditionally write a private
+  // `StewardPermissionClaim` entry to Charlie's source chain — even though that
+  // claim was for Bob, not Charlie. Then `get_my_permission_type` would query
+  // local source-chain claims without filtering by `for_agent == my_pub_key` and
+  // wrongly answer "Steward" for Charlie.
+  //
+  // Both paths now have filters: `is_agent_a_steward` only writes the claim if
+  // the queried agent is the caller, and `get_my_accountabilities` filters
+  // claims by `for_agent`. This test verifies the user-visible invariant that a
+  // cross-agent query does not pollute the caller's own accountabilities.
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
 
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
-
-    console.log('Starting conductors');
-
     const [
-      [progenitor, progenitorPubKey],
-      [steward, stewardPubKey, stewardPermissionHash],
-      [member, memberPubKey],
-    ] = await threeAgentsOneProgenitorOneStewardOneMember(scenario, appSource.appBundleSource, [
-      'group',
-    ]);
+      [_alice, _alicePubKey],
+      [_bob, bobPubKey, _bobPermissionHash],
+      [charlie, _charliePubKey],
+    ] = await threeAgentsOneProgenitorOneStewardOneMember(scenario, appBundleSource, ['group']);
 
-    const groupCellProgenitor = getCellByRoleName(progenitor, 'group');
-    const groupCellSteward = getCellByRoleName(steward, 'group');
-    const groupCellMember = getCellByRoleName(member, 'group');
+    const groupCellCharlie = getCellByRoleName(charlie, 'group');
 
-    // Normal member gets permission type of themselves to make sure the
-    // threeAgentsOneProgenitorOneStewardOneMember() function did its job correctlyu
-    const myPermissionTypeBefore: PermissionType = await groupCellMember.callZome({
+    // Sanity: Charlie has no accountabilities to start with (not progenitor, not steward).
+    const charlieAccsBefore: Accountability[] = await groupCellCharlie.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
-    assert(myPermissionTypeBefore.type === 'Member');
+    assert.equal(
+      charlieAccsBefore.length,
+      0,
+      `Charlie should have no accountabilities before any cross-agent query, got: ${JSON.stringify(charlieAccsBefore)}`,
+    );
 
-    // Normal member gets permission type of steward
-    const permissionTypeSteward: PermissionType = await groupCellMember.callZome({
+    // Charlie asks about Bob (a real steward). This is the path that pre-fix would
+    // have polluted Charlie's source chain.
+    const bobAccsViaCharlie: Accountability[] = await groupCellCharlie.callZome({
       zome_name: 'group',
-      fn_name: 'get_agent_permission_type',
-      payload: { input: groupCellSteward.cell_id[1] },
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, Date.now() * 1000], local: false },
     });
+    assert(
+      bobAccsViaCharlie.some((a) => a.type === 'Steward'),
+      `Bob should still be reported as a Steward when queried by Charlie. Got: ${JSON.stringify(bobAccsViaCharlie)}`,
+    );
 
-    // Normal member then gets permission type of themselves
-    const myPermissionTypeAfter: PermissionType = await groupCellMember.callZome({
+    // Critical: after that cross-agent query, Charlie still has no accountabilities of
+    // his own. If either filter regresses (write filter in is_agent_a_steward, or read
+    // filter in get_my_accountabilities), Charlie's source chain ends up with Bob's
+    // claim AND that claim leaks back as Charlie's accountability — both filters need
+    // to be in place to prevent the false-positive.
+    const charlieAccsAfter: Accountability[] = await groupCellCharlie.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
-    assert(myPermissionTypeAfter.type === 'Member');
+    assert.equal(
+      charlieAccsAfter.length,
+      0,
+      `Charlie's accountabilities should remain empty after querying Bob's. Got: ${JSON.stringify(charlieAccsAfter)}`,
+    );
   });
 });
 
 test('Steward can nominate additional stewards if their steward permission is not expiring', async () => {
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
 
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
-
-    const [
-      [alice, alicePubKey],
-      [bob, bobPubKey, bobPermissionHash],
-      [neitherBobNorAlice, neitherBobNorAlicePubKey],
-    ] = await threeAgentsOneProgenitorOneStewardOneMember(scenario, appSource.appBundleSource, [
-      'group',
-    ]);
+    const [[alice, _alicePubKey], [bob, _bobPubKey, bobPermissionHash], [charlie, charliePubKey]] =
+      await threeAgentsOneProgenitorOneStewardOneMember(scenario, appBundleSource, ['group']);
 
     const groupCellAlice = getCellByRoleName(alice, 'group');
     const groupCellBob = getCellByRoleName(bob, 'group');
-    const groupCellNeitherBobNorAlice = getCellByRoleName(neitherBobNorAlice, 'group');
+    const groupCellCharlie = getCellByRoleName(charlie, 'group');
 
-    // Bob creates another steward permission for nbnoralice
+    // Bob (steward, unlimited permission) issues Charlie a steward permission.
     const input: StewardPermission = {
-      for_agent: neitherBobNorAlicePubKey,
+      for_agent: charliePubKey,
       permission_hash: bobPermissionHash,
     };
 
@@ -299,62 +278,50 @@ test('Steward can nominate additional stewards if their steward permission is no
       payload: input,
     });
 
-    await dhtSync([alice, bob, neitherBobNorAlice], groupCellAlice.cell_id[0]);
+    await dhtSync([alice, bob, charlie], groupCellAlice.cell_id[0]);
 
-    // Check that permission type of nbnoralice is now indeed Steward
-    const permissionTypeNbnoralice: PermissionType = await groupCellNeitherBobNorAlice.callZome({
+    // Charlie queries his own accountabilities → should now include Steward.
+    const charlieAccs: Accountability[] = await groupCellCharlie.callZome({
       zome_name: 'group',
-      fn_name: 'get_my_permission_type',
-      payload: { input: null },
+      fn_name: 'get_my_accountabilities',
+      payload: { input: Date.now() * 1000, local: false },
     });
+    const charlieSteward = expectStewardAccountability(charlieAccs);
 
-    assert(permissionTypeNbnoralice.type === 'Steward');
     assert(
-      encodeHashToBase64(permissionTypeNbnoralice.content.permission.for_agent) ===
-        encodeHashToBase64(neitherBobNorAlicePubKey),
+      encodeHashToBase64(charlieSteward.content.permission.for_agent) ===
+        encodeHashToBase64(charliePubKey),
     );
-    assert(!permissionTypeNbnoralice.content.permission.expiry);
-    // This should be undefined/null since it has been created by the progenitor (Alice)
-    assert(!!permissionTypeNbnoralice.content.permission.permission_hash);
+    assert(!charlieSteward.content.permission.expiry);
+    // Charlie's permission was created by Bob, so its inner permission_hash points at
+    // Bob's permission (i.e. derivation chain is recorded).
+    assert(!!charlieSteward.content.permission.permission_hash);
     assert(
-      encodeHashToBase64(permissionTypeNbnoralice.content.permission.permission_hash) ===
+      encodeHashToBase64(charlieSteward.content.permission.permission_hash!) ===
         encodeHashToBase64(bobPermissionHash),
     );
     assert(
       encodeHashToBase64(permissionRecord.signed_action.hashed.hash) ===
-        encodeHashToBase64(permissionTypeNbnoralice.content.permission_hash),
+        encodeHashToBase64(charlieSteward.content.permission_hash),
     );
   });
 });
 
 test('Steward can NOT nominate additional stewards if their steward permission is expiring', async () => {
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
 
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
-
-    // Expiry is far in the future
+    // Expiry is far in the future, but it's still expiring.
     const expiry = (Date.now() + 600_000) * 1_000;
 
-    const [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
-      await twoAgentsOneProgenitorAndOneSteward(
-        scenario,
-        appSource.appBundleSource,
-        ['group'],
-        expiry,
-      );
+    const [[_alice, _alicePubKey], [bob, _bobPubKey, bobPermissionHash]] =
+      await twoAgentsOneProgenitorAndOneSteward(scenario, appBundleSource, ['group'], expiry);
 
     const groupCellBob = getCellByRoleName(bob, 'group');
 
-    // Bob creates another steward permission for nbnoralice
     const input: StewardPermission = {
       for_agent: await fakeAgentPubKey(),
       permission_hash: bobPermissionHash,
@@ -367,7 +334,7 @@ test('Steward can NOT nominate additional stewards if their steward permission i
         payload: input,
       });
       fail(
-        'Bob should not be able to create a steward permission with having only an expiring steward permission himself',
+        'Bob should not be able to create a steward permission while only holding an expiring one himself',
       );
     } catch (e) {
       if (
@@ -376,7 +343,7 @@ test('Steward can NOT nominate additional stewards if their steward permission i
           .includes('Only non-expiring StewardPermissions are allowed to take this action')
       ) {
         fail(
-          'Bob should not be able to create a steward permission with having only an expiring steward permission himself',
+          `Expected validation rejection about expiring StewardPermissions, got: ${e}`,
         );
       }
     }
@@ -385,32 +352,19 @@ test('Steward can NOT nominate additional stewards if their steward permission i
 
 test('Steward can NOT nominate additional stewards without providing a valid permission hash', async () => {
   await runScenario(async (scenario) => {
-    // Construct proper paths for your app.
-    // This assumes app bundle created by the `hc app pack` command.
-    const testAppPath = GROUP_HAPP_PATH;
-
     const appBundleSource: AppBundleSource = {
       type: 'path',
-      value: testAppPath,
+      value: GROUP_HAPP_PATH,
     };
 
-    // Set up the app to be installed
-    const appSource = { appBundleSource };
-
-    // Expiry is far in the future
+    // Expiry is far in the future.
     const expiry = (Date.now() + 600_000) * 1_000;
 
-    const [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
-      await twoAgentsOneProgenitorAndOneSteward(
-        scenario,
-        appSource.appBundleSource,
-        ['group'],
-        expiry,
-      );
+    const [[_alice, _alicePubKey], [bob, _bobPubKey, _bobPermissionHash]] =
+      await twoAgentsOneProgenitorAndOneSteward(scenario, appBundleSource, ['group'], expiry);
 
     const groupCellBob = getCellByRoleName(bob, 'group');
 
-    // Bob creates another steward permission for nbnoralice
     const input: StewardPermission = {
       for_agent: await fakeAgentPubKey(),
       permission_hash: null,
@@ -430,7 +384,7 @@ test('Steward can NOT nominate additional stewards without providing a valid per
         !e.toString().includes('No valid permission hash provided and agent is not the progenitor')
       ) {
         fail(
-          'Bob should not be able to create a steward permission with having only an expiring steward permission himself',
+          `Expected validation rejection about missing permission hash, got: ${e}`,
         );
       }
     }
@@ -438,6 +392,6 @@ test('Steward can NOT nominate additional stewards without providing a valid per
 });
 
 // TODO
-// - test that no steward permission returns member
-// - test that Steward permission entries cannot be created for oneself
-// - test retrieval of all agents' permission types
+// - test that no steward permission returns an empty Accountability list
+// - test that StewardPermission entries cannot be created for oneself
+// - test retrieval of all agents' accountabilities (get_all_agents_accountabilities)

--- a/tests/src/group/group/steward_permissions.test.ts
+++ b/tests/src/group/group/steward_permissions.test.ts
@@ -112,6 +112,7 @@ test('Create unlimited steward permission and retrieve it in different ways', as
   });
 });
 
+
 test('Create expiring steward permission and retrieve it in different ways', async () => {
   await runScenario(async (scenario) => {
     const appBundleSource: AppBundleSource = {
@@ -119,9 +120,13 @@ test('Create expiring steward permission and retrieve it in different ways', asy
       value: GROUP_HAPP_PATH,
     };
 
-    const expiry = (Date.now() + 100_000) * 1_000;
+    const now = Date.now() * 1_000;
+    const now_1 = now + 1_000 * 1_000;
+    const now_100 = now + 100_000 * 1_000;
+    const now_101 = now + 101_000 * 1_000;
+    const expiry = now_100;
 
-    const [[alice, alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
+    const [[alice, _alicePubKey], [bob, bobPubKey, bobPermissionHash]] =
       await twoAgentsOneProgenitorAndOneSteward(scenario, appBundleSource, ['group'], expiry);
 
     const groupCellBob = getCellByRoleName(bob, 'group');
@@ -131,7 +136,7 @@ test('Create expiring steward permission and retrieve it in different ways', asy
     const bobAccsBefore: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
       fn_name: 'get_agent_accountabilities',
-      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
+      payload: { input: [bobPubKey, now_1], local: true },
     });
     const bobStewardBefore = expectStewardAccountability(bobAccsBefore);
     assert(
@@ -149,7 +154,7 @@ test('Create expiring steward permission and retrieve it in different ways', asy
     const bobMyAccsBefore: Accountability[] = await groupCellBob.callZome({
       zome_name: 'group',
       fn_name: 'get_my_accountabilities',
-      payload: { input: Date.now() * 1000, local: false },
+      payload: { input: now, local: false },
     });
     const bobMyStewardBefore = expectStewardAccountability(bobMyAccsBefore);
     assert.equal(bobMyStewardBefore.content.permission.expiry, expiry);
@@ -158,29 +163,33 @@ test('Create expiring steward permission and retrieve it in different ways', asy
         encodeHashToBase64(bobPermissionHash),
     );
 
-    // Wait until the permission expires.
-    const timeUntilExpiry = expiry / 1000 - Date.now();
-    await sleep(timeUntilExpiry);
-
     // Alice's query of Bob: no longer Steward (empty array since Member is implicit).
-    const bobAccsAfter: Accountability[] = await groupCellAlice.callZome({
+    let bobAccsAfter: Accountability[] = await groupCellAlice.callZome({
       zome_name: 'group',
       fn_name: 'get_agent_accountabilities',
-      payload: { input: [bobPubKey, Date.now() * 1000], local: true },
+      payload: { input: [bobPubKey, expiry], local: true },
     });
-    assert(!bobAccsAfter.some((a) => a.type === 'Steward'));
+    assert(bobAccsAfter.some((a) => a.type === 'Steward'));
     assert(!bobAccsAfter.some((a) => a.type === 'Progenitor'));
+
+    // Alice's query of Bob: no longer Steward (empty array since Member is implicit).
+    bobAccsAfter = await groupCellAlice.callZome({
+      zome_name: 'group',
+      fn_name: 'get_agent_accountabilities',
+      payload: { input: [bobPubKey, now_101], local: true },
+    });
+    assert(bobAccsAfter.length == 0);
 
     // Bob's query of himself: also no longer Steward.
     const bobMyAccsAfter: Accountability[] = await groupCellBob.callZome({
       zome_name: 'group',
       fn_name: 'get_my_accountabilities',
-      payload: { input: Date.now() * 1000, local: false },
+      payload: { input: now_101, local: false },
     });
-    assert(!bobMyAccsAfter.some((a) => a.type === 'Steward'));
-    assert(!bobMyAccsAfter.some((a) => a.type === 'Progenitor'));
+    assert(bobMyAccsAfter.length == 0);
   });
 });
+
 
 test("get_my_accountabilities returns the correct result after querying another agent's accountabilities", async () => {
   // Regression test for the privilege-escalation bug fixed in commit 48211967.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,10 +1688,10 @@
     lodash-es "^4.17.21"
     ws "^8.18.3"
 
-"@holochain/tryorama@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.19.0.tgz"
-  integrity sha512-qDAXfphyTCg5RjTyOt/wQt9/3sUhf3FlqMxo6HLnhiTP4Dp4zkJyOvrhXtEgfzZt3fa97/L2BME2vZIymTnjug==
+"@holochain/tryorama@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@holochain/tryorama/-/tryorama-0.19.1.tgz#ea1bebbca635b795d6e9a1ddc6cd03c5772cb7d6"
+  integrity sha512-Sx/55mzVZeHMlp6G5WAQCTv3T9zRBuK/oQTQ1zuRuVW6OWMsaZ2tAcW/rPekvlLAZ0Rd9iTYDUCPBVHDB8B1Ig==
   dependencies:
     "@holochain/client" "^0.20.0"
     get-port "^7.0.0"


### PR DESCRIPTION
Restores steward-permission tests and add privilege-escalation regression:

The steward_permissions and group_profile test suites have been broken since commit ef3c8cb6 (Dec 2025) renamed the zome's PermissionType to Accountability and changed the response shape to a Vec — the rename left the test helpers commented out without porting the call sites. Eight tests were calling helpers that no longer existed.

This commit restores the three multi-agent helpers in common.ts (nAgentsOneProgenitor, twoAgentsOneProgenitorAndOneSteward, threeAgentsOneProgenitorOneStewardOneMember) against the new Accountability[] zome surface, and ports steward_permissions.test.ts to use get_my_accountabilities / get_agent_accountabilities. Also fixes a pre-existing off-by-one in nAgentsOneProgenitor that was creating one extra agent.

Adds a new regression test for the privilege-escalation bug fixed in commit 48211967 (Jul 2025): a non-privileged agent (Charlie) querying a steward's (Bob's) accountabilities used to pollute Charlie's source chain with a Bob-labeled StewardPermissionClaim, which the unfiltered get_my_permission_type would then return as Charlie's own Steward status. The fix added two filters (one in is_agent_a_steward, one in get_my_accountabilities); the test asserts the user-visible invariant that a cross-agent query does not leak into the caller's own accountabilities. No regression test was added at the time of the fix.

Bumps @holochain/tryorama 0.19.0 -> 0.19.1 to fix a pre-existing infrastructure mismatch: 0.19.0 calls `hc sandbox create network webrtc` but hc 0.6.1-rc.7 (the pinned version in moss.config.json) renamed that subcommand to `quic` mid-rc-cycle. Without this bump no tryorama scenario can start. 0.19.1 has the rename.

Adds two missing CI steps to test.yaml (Ubuntu-only, mirroring the example-applet step): build group.happ from source (rather than only fetching the pre-built one), and run `yarn test`. The workflow had never run the integration suite, which is why all of the above went unnoticed for months.
