### PR TITLE
fix: targeted reload on tool activation and enable/disable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Moss is a Holochain-based runtime for composable peer-to-peer collaboration tool
 3. Don't add claude co-authored/generated messages in commit descriptions
 4. **Strong typing**: when possible allways use strong typing in typescript.
 5. **Holochain reference sources**: We are using Holochain 0.6.  The source for this is local and lives at the same level as this repo. DO NOT USE .cargo files or web searches to research holochain, just look locally.
+6. **Code comments**: Code comments must explain intent (what the code is trying to achieve), not the change itself. Do not write comments that compare to prior behavior, contrast with other functions, or describe what the code is *no longer* doing — that belongs in the PR description or commit message.
 
 ## Development Commands
 

--- a/src/renderer/src/elements/_new_design/group-settings/applet-settings-card.ts
+++ b/src/renderer/src/elements/_new_design/group-settings/applet-settings-card.ts
@@ -307,6 +307,13 @@ export class AppletSettingsCard extends BaseAppletSettingsCard {
           await this.mossStore.enableApplet(this.appletHash);
           notify(msg('Tool enabled.'));
         }
+        // Refresh local appInfo so the switch reflects the new state.
+        // Previously this happened implicitly because the surrounding
+        // dialog was unmounted/remounted by reloadManualStores().
+        const [appletClient] = await this.mossStore.getAppClient(
+          appIdFromAppletHash(this.appletHash),
+        );
+        this.appInfo = await appletClient.appInfo();
       }}
         >
         </sl-switch>

--- a/src/renderer/src/elements/_new_design/group-settings/applet-settings-card.ts
+++ b/src/renderer/src/elements/_new_design/group-settings/applet-settings-card.ts
@@ -308,8 +308,6 @@ export class AppletSettingsCard extends BaseAppletSettingsCard {
           notify(msg('Tool enabled.'));
         }
         // Refresh local appInfo so the switch reflects the new state.
-        // Previously this happened implicitly because the surrounding
-        // dialog was unmounted/remounted by reloadManualStores().
         const [appletClient] = await this.mossStore.getAppClient(
           appIdFromAppletHash(this.appletHash),
         );

--- a/src/renderer/src/elements/_new_design/group-settings/inactive-tools.ts
+++ b/src/renderer/src/elements/_new_design/group-settings/inactive-tools.ts
@@ -42,7 +42,7 @@ export class InactiveTools extends LitElement {
 
       // Only reload for single activations; batch activation reloads once at the end
       if (!this._activatingAll) {
-        await this._mossStore.reloadManualStores();
+        await this._mossStore.reloadAfterAppletActivation(this._groupStore);
       }
 
       // Don't dispatch 'applet-installed' event here to keep the settings window open
@@ -145,7 +145,7 @@ export class InactiveTools extends LitElement {
     }
 
     // Reload stores once after all activations complete
-    await this._mossStore.reloadManualStores();
+    await this._mossStore.reloadAfterAppletActivation(this._groupStore);
 
     this._activatingAll = false;
 

--- a/src/renderer/src/groups/elements/applet-detail-card.ts
+++ b/src/renderer/src/groups/elements/applet-detail-card.ts
@@ -531,6 +531,13 @@ export class AppletDetailCard extends LitElement {
           await this.mossStore.enableApplet(this.appletHash);
           notify(msg('Tool enabled.'));
         }
+        // Refresh local appInfo so the switch reflects the new state.
+        // Previously this happened implicitly because the surrounding
+        // dialog was unmounted/remounted by reloadManualStores().
+        const [appletClient] = await this.mossStore.getAppClient(
+          appIdFromAppletHash(this.appletHash),
+        );
+        this.appInfo = await appletClient.appInfo();
       }}
               >
               </sl-switch>

--- a/src/renderer/src/groups/elements/applet-detail-card.ts
+++ b/src/renderer/src/groups/elements/applet-detail-card.ts
@@ -532,8 +532,6 @@ export class AppletDetailCard extends LitElement {
           notify(msg('Tool enabled.'));
         }
         // Refresh local appInfo so the switch reflects the new state.
-        // Previously this happened implicitly because the surrounding
-        // dialog was unmounted/remounted by reloadManualStores().
         const [appletClient] = await this.mossStore.getAppClient(
           appIdFromAppletHash(this.appletHash),
         );

--- a/src/renderer/src/groups/elements/group-home.ts
+++ b/src/renderer/src/groups/elements/group-home.ts
@@ -494,7 +494,7 @@ export class GroupHome extends LitElement {
     this._joiningNewApplet = encodeHashToBase64(appletHash);
     try {
       await this._groupStore.installApplet(appletHash);
-      await this.mossStore.reloadManualStores();
+      await this.mossStore.reloadAfterAppletActivation(this._groupStore);
       this.dispatchEvent(
         new CustomEvent('applet-installed', {
           detail: {

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -1421,7 +1421,7 @@ export class MossStore {
     await this.adminWebsocket.disableApp({
       installed_app_id: appIdFromAppletHash(appletHash),
     });
-    await this.reloadManualStores();
+    await this.reloadAfterAppletEnableDisable(appletHash);
   }
 
   async enableApplet(appletHash: EntryHash) {
@@ -1431,7 +1431,7 @@ export class MossStore {
     await this.adminWebsocket.enableApp({
       installed_app_id: appIdFromAppletHash(appletHash),
     });
-    await this.reloadManualStores();
+    await this.reloadAfterAppletEnableDisable(appletHash);
   }
 
   /**
@@ -1894,6 +1894,43 @@ export class MossStore {
     // );
     await this.installedApps.reload();
     await this.allAppAssetInfos.reload();
+  }
+
+  /**
+   * Targeted reload after activating (joining) an existing applet in a group.
+   *
+   * Unlike reloadManualStores(), this does NOT call groupStores.reload(), which
+   * would destroy and recreate every GroupStore instance and cause the
+   * surrounding UI (settings dialogs, sidebars, etc.) to unmount/remount via
+   * Lit context invalidation. Activation does not change the set of groups, so
+   * the existing GroupStore for the activating group is still valid; only its
+   * joined-applet state and the conductor's installed-app list need to refresh.
+   */
+  async reloadAfterAppletActivation(groupStore: GroupStore) {
+    await this.installedApps.reload();
+    await this.allAppAssetInfos.reload();
+    await groupStore.allMyApplets.reload();
+    await groupStore.allMyInstalledApplets.reload();
+    await groupStore.allMyRunningApplets.reload();
+  }
+
+  /**
+   * Targeted reload after enabling/disabling an existing applet.
+   *
+   * Same rationale as reloadAfterAppletActivation: avoid groupStores.reload()
+   * so the surrounding settings UI does not unmount. Enable/disable does not
+   * change which applets are joined or which groups exist; it only changes the
+   * conductor's running-app set, so refresh installedApps and the per-group
+   * allMyRunningApplets for every group containing this applet.
+   */
+  async reloadAfterAppletEnableDisable(appletHash: AppletHash) {
+    await this.installedApps.reload();
+    const groupStores = await toPromise(this.groupsForApplet.get(appletHash)!);
+    await Promise.all(
+      Array.from(groupStores.values()).map(async (gs) => {
+        if (gs) await gs.allMyRunningApplets.reload();
+      }),
+    );
   }
 
   async emitParentToAppletMessage(message: ParentToAppletMessage, forApplets: AppletId[]) {

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -1897,14 +1897,9 @@ export class MossStore {
   }
 
   /**
-   * Targeted reload after activating (joining) an existing applet in a group.
-   *
-   * Unlike reloadManualStores(), this does NOT call groupStores.reload(), which
-   * would destroy and recreate every GroupStore instance and cause the
-   * surrounding UI (settings dialogs, sidebars, etc.) to unmount/remount via
-   * Lit context invalidation. Activation does not change the set of groups, so
-   * the existing GroupStore for the activating group is still valid; only its
-   * joined-applet state and the conductor's installed-app list need to refresh.
+   * Refresh the stores that go stale when an applet is activated (joined) in a
+   * group: the conductor's installed-app list and the activating group's
+   * joined-applet state.
    */
   async reloadAfterAppletActivation(groupStore: GroupStore) {
     await this.installedApps.reload();
@@ -1915,13 +1910,9 @@ export class MossStore {
   }
 
   /**
-   * Targeted reload after enabling/disabling an existing applet.
-   *
-   * Same rationale as reloadAfterAppletActivation: avoid groupStores.reload()
-   * so the surrounding settings UI does not unmount. Enable/disable does not
-   * change which applets are joined or which groups exist; it only changes the
-   * conductor's running-app set, so refresh installedApps and the per-group
-   * allMyRunningApplets for every group containing this applet.
+   * Refresh the stores that go stale when an applet is enabled or disabled:
+   * the conductor's installed-app list and the running-applets store of every
+   * group containing this applet.
    */
   async reloadAfterAppletEnableDisable(appletHash: AppletHash) {
     await this.installedApps.reload();


### PR DESCRIPTION
Fix for Issue: https://github.com/lightningrodlabs/moss/issues/191

reloadManualStores() calls groupStores.reload(), which destroys and recreates every GroupStore instance. That cascades through Lit context (group-context -> group-home), forces the groupProfile StoreSubscriber through pending, and unmounts the settings dialog and its <group-settings> element. On remount, GroupSettings defaults to its General tab — so activating or toggling a tool snapped the user back to General instead of staying on Group Tools.

Activation does not change the set of groups, and enable/disable does not change which applets are joined. Add two targeted reload helpers on MossStore that skip groupStores.reload() and only refresh the stores that actually went stale:

- reloadAfterAppletActivation: installedApps, allAppAssetInfos, and the activating group's allMyApplets / allMyInstalledApplets / allMyRunningApplets.
- reloadAfterAppletEnableDisable: installedApps, plus allMyRunningApplets for every group containing the applet (resolved via groupsForApplet).

Switch the activate flows (inactive-tools and group-home.joinNewApplet) and disableApplet/enableApplet over to these helpers. The settings dialog now stays mounted across the operation, so the tab persists.

Because the surrounding card is no longer remounted on toggle, the local appInfo in applet-settings-card and applet-detail-card no longer refreshes implicitly; refetch it after the toggle so the switch reflects the new running state.