### PR TITLE
Feat/import seed forking

### DIFF
--- a/src/main/cli/cli.ts
+++ b/src/main/cli/cli.ts
@@ -33,6 +33,8 @@ export const APPLET_DEV_TMP_FOLDER_PREFIX = 'moss-applet-dev';
 
 export interface CliOpts {
   profile?: string;
+  seedFork?: string;
+  seedfork?: string;
   devConfig?: string | undefined;
   devDataDir?: string | undefined;
   agentIdx?: number | undefined;
@@ -54,6 +56,7 @@ export interface CliOpts {
 
 export interface RunOptions {
   profile: string | undefined;
+  seedFork: string | undefined;
   appstoreNetworkSeed: string;
   devInfo: WeAppletDevInfo | undefined;
   bootstrapUrl: string | undefined;
@@ -70,6 +73,8 @@ export interface RunOptions {
 }
 
 export function validateArgs(args: CliOpts): RunOptions {
+  const seedFork = args.seedFork ?? args.seedfork;
+
   // validate --profile argument
   const allowedProfilePattern = /^[0-9a-zA-Z-]+$/;
   if (args.profile && !allowedProfilePattern.test(args.profile)) {
@@ -126,6 +131,9 @@ export function validateArgs(args: CliOpts): RunOptions {
   if (args.holochainPath && typeof args.holochainPath !== 'string') {
     throw new Error('The --holochain-path argument must be of type string.');
   }
+  if (seedFork && typeof seedFork !== 'string') {
+    throw new Error('The --seed-fork/--seedfork argument must be of type string.');
+  }
   if (args.holochainRustLog && typeof args.holochainRustLog !== 'string') {
     throw new Error('The --holochain-rust-log argument must be of type string.');
   }
@@ -176,6 +184,7 @@ export function validateArgs(args: CliOpts): RunOptions {
 
   return {
     profile,
+    seedFork: seedFork ? seedFork : undefined,
     appstoreNetworkSeed,
     devInfo,
     bootstrapUrl: args.bootstrapUrl,
@@ -319,7 +328,7 @@ function readAndValidateDevConfig(
   const allGroupNetworkSeeds = groups.map((group) => group.networkSeed);
   const uniqueGroupNetworkSeeds = new Set(allGroupNetworkSeeds);
   if (uniqueGroupNetworkSeeds.size !== allGroupNetworkSeeds.length) {
-      throw new Error(`Invalid We dev config: Group network seeds must all be unique.`);
+    throw new Error(`Invalid We dev config: Group network seeds must all be unique.`);
   }
   // validate applets
   applets.forEach((applet) => {
@@ -389,7 +398,7 @@ function readAndValidateDevConfig(
   });
 
   if (configObject && !configObject.toolCurations) {
-      configObject.toolCurations = [];
+    configObject.toolCurations = [];
   }
 
   const allAppletNames = applets.map((applet) => applet.name);

--- a/src/main/cli/cli.ts
+++ b/src/main/cli/cli.ts
@@ -33,8 +33,7 @@ export const APPLET_DEV_TMP_FOLDER_PREFIX = 'moss-applet-dev';
 
 export interface CliOpts {
   profile?: string;
-  seedFork?: string;
-  seedfork?: string;
+  fork?: string;
   devConfig?: string | undefined;
   devDataDir?: string | undefined;
   agentIdx?: number | undefined;
@@ -56,7 +55,7 @@ export interface CliOpts {
 
 export interface RunOptions {
   profile: string | undefined;
-  seedFork: string | undefined;
+  fork: string | undefined;
   appstoreNetworkSeed: string;
   devInfo: WeAppletDevInfo | undefined;
   bootstrapUrl: string | undefined;
@@ -73,7 +72,7 @@ export interface RunOptions {
 }
 
 export function validateArgs(args: CliOpts): RunOptions {
-  const seedFork = args.seedFork ?? args.seedfork;
+  const fork = args.fork;
 
   // validate --profile argument
   const allowedProfilePattern = /^[0-9a-zA-Z-]+$/;
@@ -131,8 +130,8 @@ export function validateArgs(args: CliOpts): RunOptions {
   if (args.holochainPath && typeof args.holochainPath !== 'string') {
     throw new Error('The --holochain-path argument must be of type string.');
   }
-  if (seedFork && typeof seedFork !== 'string') {
-    throw new Error('The --seed-fork/--seedfork argument must be of type string.');
+  if (fork && typeof fork !== 'string') {
+    throw new Error('The --fork argument must be of type string.');
   }
   if (args.holochainRustLog && typeof args.holochainRustLog !== 'string') {
     throw new Error('The --holochain-rust-log argument must be of type string.');
@@ -184,7 +183,7 @@ export function validateArgs(args: CliOpts): RunOptions {
 
   return {
     profile,
-    seedFork: seedFork ? seedFork : undefined,
+    fork: fork ? fork : undefined,
     appstoreNetworkSeed,
     devInfo,
     bootstrapUrl: args.bootstrapUrl,

--- a/src/main/cli/cli.ts
+++ b/src/main/cli/cli.ts
@@ -183,7 +183,7 @@ export function validateArgs(args: CliOpts): RunOptions {
 
   return {
     profile,
-    fork: fork ? fork : undefined,
+    fork: fork ? fork : undefined, // coerce '' to undefined so an empty --fork is a no-op
     appstoreNetworkSeed,
     devInfo,
     bootstrapUrl: args.bootstrapUrl,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -178,6 +178,11 @@ program
     'Runs Moss with a custom profile with its own dedicated data store.',
   )
   .option(
+    '--seed-fork <string>',
+    'When importing existing data, appends this suffix to all imported network seeds.',
+  )
+  .addOption(new Option('--seedfork <string>').hideHelp())
+  .option(
     '-n, --network-seed <string>',
     'Installs any default apps with the provided network seed in case there are any and have not yet been installed.',
   )
@@ -1059,21 +1064,21 @@ if (!RUNNING_WITH_COMMAND) {
         app.quit();
       }
     }),
-    ipcMain.handle('get-network-overrides', () => {
-      const overrides = WE_FILE_SYSTEM.getNetworkOverrides();
-      const networkUrls = getNetworkUrls();
-      return {
-        overrides,
-        defaults: {
-          bootstrapUrl: PRODUCTION_BOOTSTRAP_URLS[0],
-          relayUrl: PRODUCTION_RELAY_URLS[0],
-        },
-        current: {
-          bootstrapUrl: networkUrls.bootstrap_urls[0],
-          relayUrl: networkUrls.relay_urls[0],
-        },
-      };
-    });
+      ipcMain.handle('get-network-overrides', () => {
+        const overrides = WE_FILE_SYSTEM.getNetworkOverrides();
+        const networkUrls = getNetworkUrls();
+        return {
+          overrides,
+          defaults: {
+            bootstrapUrl: PRODUCTION_BOOTSTRAP_URLS[0],
+            relayUrl: PRODUCTION_RELAY_URLS[0],
+          },
+          current: {
+            bootstrapUrl: networkUrls.bootstrap_urls[0],
+            relayUrl: networkUrls.relay_urls[0],
+          },
+        };
+      });
     ipcMain.handle('set-network-overrides', async (_e, overrides: { bootstrapUrl?: string; relayUrl?: string }) => {
       WE_FILE_SYSTEM.setNetworkOverrides(overrides);
       // Relaunch Moss
@@ -1110,7 +1115,7 @@ if (!RUNNING_WITH_COMMAND) {
       app.relaunch(options);
       app.quit();
     });
-      ipcMain.handle('is-main-window-focused', (): boolean | undefined => MAIN_WINDOW?.isFocused());
+    ipcMain.handle('is-main-window-focused', (): boolean | undefined => MAIN_WINDOW?.isFocused());
     ipcMain.handle(
       'notification',
       (
@@ -1486,7 +1491,7 @@ if (!RUNNING_WITH_COMMAND) {
       let network_info: NetworkInfo = { bootstrap_urls: [], signal_urls: [], relay_urls: [] };
       try {
         network_info = getNetworkUrls();
-      } catch (e) {console.error('Failed to get network urls', e)}
+      } catch (e) { console.error('Failed to get network urls', e) }
       /** */
       return HOLOCHAIN_MANAGER
         ? {
@@ -1800,6 +1805,12 @@ if (!RUNNING_WITH_COMMAND) {
     // Execute a groups import from a parsed array. Used by both dialog-based and
     // auto-import (pending) flows.
     const runGroupsImport = async (groups: GroupExportEntry[]): Promise<ImportResult[]> => {
+      const forkImportedSeed = (seed: string | undefined): string | undefined => {
+        if (!seed || !RUN_OPTIONS.seedFork) return seed;
+        console.log(`Forking imported seed "${seed}" with fork "${RUN_OPTIONS.seedFork}"`);
+        return `${seed}${RUN_OPTIONS.seedFork}`;
+      };
+
       const allApps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
       let myPubKey = globalPubKeyFromListAppsResponse(allApps);
       if (!myPubKey) myPubKey = await getOrCreateAgentPubKey();
@@ -1814,7 +1825,9 @@ if (!RUNNING_WITH_COMMAND) {
       for (let gi = 0; gi < groups.length; gi++) {
         const group = groups[gi];
         const current = gi + 1;
-        const { networkSeed, progenitor, groupProfile, agentProfile, description } = group;
+        const { progenitor, groupProfile, agentProfile, description } = group;
+        const networkSeed = forkImportedSeed(group.networkSeed);
+        console.log(`Importing group ${current}/${total}: "${groupProfile?.name || 'Unnamed'}" with network seed "${networkSeed}" and progenitor "${progenitor}"`);
 
         if (!networkSeed) {
           results.push({ groupName: groupProfile?.name, status: 'error', error: 'Missing network seed' });
@@ -1944,6 +1957,7 @@ if (!RUNNING_WITH_COMMAND) {
           if (group.tools && group.tools.length > 0) {
             for (let ti = 0; ti < group.tools.length; ti++) {
               const tool = group.tools[ti];
+              const toolNetworkSeed = forkImportedSeed(tool.network_seed);
               emitProgress(current, groupProfile?.name, 'installing-tool', {
                 toolName: tool.toolName || tool.custom_name,
                 toolIndex: ti + 1,
@@ -1995,7 +2009,7 @@ if (!RUNNING_WITH_COMMAND) {
                   sha256_ui: sha256Ui,
                   sha256_webhapp: sha256Webhapp,
                   distribution_info: JSON.stringify(newDistributionInfo),
-                  network_seed: tool.network_seed,
+                  network_seed: toolNetworkSeed,
                   properties: {},
                 };
 
@@ -2057,7 +2071,7 @@ if (!RUNNING_WITH_COMMAND) {
                     fs.writeFileSync(webHappPath, new Uint8Array(buffer));
                     const { happPath } = await rustUtils.saveHappOrWebhapp(webHappPath, happsDir, uisDir);
                     happToBeInstalledPath = happPath;
-                    try { fs.rmSync(tmpImportDir, { recursive: true }); } catch (_) {}
+                    try { fs.rmSync(tmpImportDir, { recursive: true }); } catch (_) { }
                   }
 
                   const appAssetsInfo: AppAssetsInfo = deriveAppAssetsInfo(
@@ -2073,7 +2087,7 @@ if (!RUNNING_WITH_COMMAND) {
                     source: { type: 'path', value: happToBeInstalledPath },
                     installed_app_id: appletAppId,
                     agent_key: myPubKey,
-                    network_seed: tool.network_seed,
+                    network_seed: toolNetworkSeed,
                   });
                   await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appletAppId });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1871,7 +1871,7 @@ if (!RUNNING_WITH_COMMAND) {
           });
 
           let importGroupStatus: ImportStatus;
-          if (amProgenitor) {
+          if (amProgenitor || !progenitor) {
             if (groupProfile) {
               emitProgress(current, groupProfile?.name, 'setting-profile');
               await appWs.callZome({
@@ -1891,49 +1891,7 @@ if (!RUNNING_WITH_COMMAND) {
             }
             importGroupStatus = 'created';
           } else {
-            let profileSynced = false;
-            const deadline = Date.now() + 20000;
-            while (Date.now() < deadline) {
-              const secondsLeft = Math.ceil((deadline - Date.now()) / 1000);
-              emitProgress(current, groupProfile?.name, 'waiting-for-sync', { secondsLeft });
-              await new Promise((r) => setTimeout(r, 5000));
-              try {
-                const profileRecord = await appWs.callZome({
-                  role_name: 'group',
-                  zome_name: 'group',
-                  fn_name: 'get_group_profile',
-                  payload: { input: null, local: false },
-                });
-                if (profileRecord) { profileSynced = true; break; }
-              } catch (_pollErr) {
-                // continue polling
-              }
-            }
-
-            if (profileSynced) {
-              importGroupStatus = 'joined';
-            } else if (!progenitor) {
-              if (groupProfile) {
-                emitProgress(current, groupProfile?.name, 'setting-profile');
-                await appWs.callZome({
-                  role_name: 'group',
-                  zome_name: 'group',
-                  fn_name: 'set_group_profile',
-                  payload: { name: groupProfile.name, icon_src: groupProfile.icon_src },
-                });
-              }
-              if (description) {
-                await appWs.callZome({
-                  role_name: 'group',
-                  zome_name: 'group',
-                  fn_name: 'set_group_meta_data',
-                  payload: { name: 'description', data: description, permission_hash: null },
-                });
-              }
-              importGroupStatus = 'created';
-            } else {
-              importGroupStatus = 'joined-no-profile';
-            }
+            importGroupStatus = 'joined-no-profile';
           }
 
           // Set the agent's own profile in this group if we have one from the export.
@@ -1962,6 +1920,14 @@ if (!RUNNING_WITH_COMMAND) {
           }
 
           if (group.tools && group.tools.length > 0) {
+            if (progenitor && !amProgenitor) {
+              console.log(
+                `Skipping tool import for group ${appId} because importing agent is not the listed progenitor.`
+              );
+            }
+          }
+
+          if (group.tools && group.tools.length > 0 && (amProgenitor || !progenitor)) {
             for (let ti = 0; ti < group.tools.length; ti++) {
               const tool = group.tools[ti];
               const toolNetworkSeed = forkImportedSeed(tool.network_seed);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1939,6 +1939,13 @@ if (!RUNNING_WITH_COMMAND) {
           // Set the agent's own profile in this group if we have one from the export.
           if (agentProfile) {
             try {
+              const normalizedAgentFields =
+                agentProfile.fields &&
+                  typeof agentProfile.fields === 'object' &&
+                  !Array.isArray(agentProfile.fields)
+                  ? agentProfile.fields
+                  : {};
+
               emitProgress(current, groupProfile?.name, 'setting-profile');
               await appWs.callZome({
                 role_name: 'group',
@@ -1946,7 +1953,7 @@ if (!RUNNING_WITH_COMMAND) {
                 fn_name: 'create_profile',
                 payload: {
                   nickname: agentProfile.nickname,
-                  fields: agentProfile.fields,
+                  fields: normalizedAgentFields,
                 },
               });
             } catch (profileErr) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -134,6 +134,33 @@ if (ranViaCli) {
 
 let RUNNING_WITH_COMMAND = true;
 
+// Truncate a network seed for log output. Seeds are stored in plaintext on
+// disk anyway (moss-groups-export.json, conductor config), so this is not
+// access control — it just keeps full seeds out of logs, which are the
+// artifact users tend to share in bug reports.
+function redactSeed(seed: string | undefined): string {
+  if (!seed) return '<none>';
+  return seed.length <= 8 ? '********' : `${seed.slice(0, 8)}…`;
+}
+
+// Optionally fork an imported network seed by appending the --fork suffix.
+//
+// NOTE: a network seed is hashed into the DNA/cell identity, so changing it
+// does NOT merely fork the source chain — it places the imported group/tool
+// into an entirely separate, isolated DHT network that will not sync with the
+// original group's peers. This is intended for running multiple profiles of
+// the same Moss version on one machine without source-chain forking; a forked
+// profile is deliberately disconnected from the real shared network.
+function forkImportedSeed(seed: string | undefined, fork: string | undefined): string | undefined {
+  if (!fork) return seed; // normal, unforked import — leave the seed untouched
+  if (!seed) {
+    console.warn('No seed provided. Skipping seed forking.');
+    return undefined;
+  }
+  console.log(`Forking imported seed "${redactSeed(seed)}" with fork "${fork}"`);
+  return `${seed}${fork}`;
+}
+
 // CLI command to compute the sha256 of a webhapp
 const hashWebhapp = new Command();
 hashWebhapp
@@ -420,6 +447,10 @@ if (!RUNNING_WITH_COMMAND) {
   let SYSTRAY: Tray | undefined = undefined;
   let isAppQuitting = false;
   let LOCAL_SERVICES_HANDLE: childProcess.ChildProcessWithoutNullStreams | undefined;
+  // A custom --profile normally means the user wants a fresh, dedicated data
+  // store, so we skip the legacy-import prompt. The exception is --fork: forking
+  // imported seeds only makes sense as part of the import flow, so when --fork
+  // is set we keep the prompt so the import path stays reachable.
   const skipLegacyProfileImportPrompt = !!RUN_OPTIONS.profile && !RUN_OPTIONS.fork;
   const WAL_WINDOWS: Record<
     string,
@@ -1810,19 +1841,6 @@ if (!RUNNING_WITH_COMMAND) {
     // Execute a groups import from a parsed array. Used by both dialog-based and
     // auto-import (pending) flows.
     const runGroupsImport = async (groups: GroupExportEntry[]): Promise<ImportResult[]> => {
-      const forkImportedSeed = (seed: string | undefined): string | undefined => {
-        if (!seed) {
-          console.warn('No seed provided for group. Skipping seed forking.');
-          return undefined;
-        } else if (!RUN_OPTIONS.fork) {
-          console.warn('Fork option is enabled but no seed fork string provided. Skipping seed forking.');
-          return seed;
-        } else {
-          console.log(`Forking imported seed "${seed}" with fork "${RUN_OPTIONS.fork}"`);
-          return `${seed}${RUN_OPTIONS.fork}`;
-        }
-      };
-
       const allApps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
       let myPubKey = globalPubKeyFromListAppsResponse(allApps);
       if (!myPubKey) myPubKey = await getOrCreateAgentPubKey();
@@ -1838,8 +1856,8 @@ if (!RUNNING_WITH_COMMAND) {
         const group = groups[gi];
         const current = gi + 1;
         const { progenitor, groupProfile, agentProfile, description } = group;
-        const networkSeed = forkImportedSeed(group.networkSeed);
-        console.log(`Importing group ${current}/${total}: "${groupProfile?.name || 'Unnamed'}" with network seed "${networkSeed}" and progenitor "${progenitor}"`);
+        const networkSeed = forkImportedSeed(group.networkSeed, RUN_OPTIONS.fork);
+        console.log(`Importing group ${current}/${total}: "${groupProfile?.name || 'Unnamed'}" with network seed "${redactSeed(networkSeed)}" and progenitor "${progenitor}"`);
 
         if (!networkSeed) {
           results.push({ groupName: groupProfile?.name, status: 'error', error: 'Missing network seed' });
@@ -1909,10 +1927,14 @@ if (!RUNNING_WITH_COMMAND) {
           // Set the agent's own profile in this group if we have one from the export.
           if (agentProfile) {
             try {
+              // The `profiles` zome expects `fields` to be a plain object map.
+              // Exported data can be hand-edited or come from older versions,
+              // so coerce anything that isn't a plain object (null, array,
+              // primitive) to an empty object to avoid a zome-call rejection.
               const normalizedAgentFields =
                 agentProfile.fields &&
-                  typeof agentProfile.fields === 'object' &&
-                  !Array.isArray(agentProfile.fields)
+                typeof agentProfile.fields === 'object' &&
+                !Array.isArray(agentProfile.fields)
                   ? agentProfile.fields
                   : {};
 
@@ -1931,18 +1953,18 @@ if (!RUNNING_WITH_COMMAND) {
             }
           }
 
-          if (group.tools && group.tools.length > 0) {
-            if (progenitor && !amProgenitor) {
-              console.log(
-                `Skipping tool import for group ${appId} because importing agent is not the listed progenitor.`
-              );
-            }
-          }
-
-          if (group.tools && group.tools.length > 0 && (amProgenitor || !progenitor)) {
+          // Only the progenitor (or a non-progenitor-gated group) installs tools
+          // on import; a stewarded group joined by a non-progenitor picks up its
+          // tools by syncing instead.
+          const shouldImportTools = amProgenitor || !progenitor;
+          if (group.tools && group.tools.length > 0 && !shouldImportTools) {
+            console.log(
+              `Skipping tool import for group ${appId} because importing agent is not the listed progenitor.`,
+            );
+          } else if (group.tools && group.tools.length > 0) {
             for (let ti = 0; ti < group.tools.length; ti++) {
               const tool = group.tools[ti];
-              const toolNetworkSeed = forkImportedSeed(tool.network_seed);
+              const toolNetworkSeed = forkImportedSeed(tool.network_seed, RUN_OPTIONS.fork);
               emitProgress(current, groupProfile?.name, 'installing-tool', {
                 toolName: tool.toolName || tool.custom_name,
                 toolIndex: ti + 1,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1064,21 +1064,21 @@ if (!RUNNING_WITH_COMMAND) {
         app.quit();
       }
     }),
-      ipcMain.handle('get-network-overrides', () => {
-        const overrides = WE_FILE_SYSTEM.getNetworkOverrides();
-        const networkUrls = getNetworkUrls();
-        return {
-          overrides,
-          defaults: {
-            bootstrapUrl: PRODUCTION_BOOTSTRAP_URLS[0],
-            relayUrl: PRODUCTION_RELAY_URLS[0],
-          },
-          current: {
-            bootstrapUrl: networkUrls.bootstrap_urls[0],
-            relayUrl: networkUrls.relay_urls[0],
-          },
-        };
-      });
+    ipcMain.handle('get-network-overrides', () => {
+      const overrides = WE_FILE_SYSTEM.getNetworkOverrides();
+      const networkUrls = getNetworkUrls();
+      return {
+        overrides,
+        defaults: {
+          bootstrapUrl: PRODUCTION_BOOTSTRAP_URLS[0],
+          relayUrl: PRODUCTION_RELAY_URLS[0],
+        },
+        current: {
+          bootstrapUrl: networkUrls.bootstrap_urls[0],
+          relayUrl: networkUrls.relay_urls[0],
+        },
+      };
+    });
     ipcMain.handle('set-network-overrides', async (_e, overrides: { bootstrapUrl?: string; relayUrl?: string }) => {
       WE_FILE_SYSTEM.setNetworkOverrides(overrides);
       // Relaunch Moss

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -178,10 +178,9 @@ program
     'Runs Moss with a custom profile with its own dedicated data store.',
   )
   .option(
-    '--seed-fork <string>',
+    '--fork <string>',
     'When importing existing data, appends this suffix to all imported network seeds.',
   )
-  .addOption(new Option('--seedfork <string>').hideHelp())
   .option(
     '-n, --network-seed <string>',
     'Installs any default apps with the provided network seed in case there are any and have not yet been installed.',
@@ -421,6 +420,7 @@ if (!RUNNING_WITH_COMMAND) {
   let SYSTRAY: Tray | undefined = undefined;
   let isAppQuitting = false;
   let LOCAL_SERVICES_HANDLE: childProcess.ChildProcessWithoutNullStreams | undefined;
+  const skipLegacyProfileImportPrompt = !!RUN_OPTIONS.profile && !RUN_OPTIONS.fork;
   const WAL_WINDOWS: Record<
     string,
     {
@@ -1532,6 +1532,11 @@ if (!RUNNING_WITH_COMMAND) {
       return !WE_FILE_SYSTEM.keystoreInitialized();
     });
     ipcMain.handle('find-legacy-profiles', (): LegacyProfileInfo[] => {
+      // Skip the legacy import choice for explicit custom profiles, but still let
+      // the renderer continue into the normal first-launch setup flow.
+      if (skipLegacyProfileImportPrompt) {
+        return [];
+      }
       return findLegacyProfiles(app);
     });
     ipcMain.handle('get-lair-binary-version', (): string => {
@@ -1806,9 +1811,16 @@ if (!RUNNING_WITH_COMMAND) {
     // auto-import (pending) flows.
     const runGroupsImport = async (groups: GroupExportEntry[]): Promise<ImportResult[]> => {
       const forkImportedSeed = (seed: string | undefined): string | undefined => {
-        if (!seed || !RUN_OPTIONS.seedFork) return seed;
-        console.log(`Forking imported seed "${seed}" with fork "${RUN_OPTIONS.seedFork}"`);
-        return `${seed}${RUN_OPTIONS.seedFork}`;
+        if (!seed) {
+          console.warn('No seed provided for group. Skipping seed forking.');
+          return undefined;
+        } else if (!RUN_OPTIONS.fork) {
+          console.warn('Fork option is enabled but no seed fork string provided. Skipping seed forking.');
+          return seed;
+        } else {
+          console.log(`Forking imported seed "${seed}" with fork "${RUN_OPTIONS.fork}"`);
+          return `${seed}${RUN_OPTIONS.fork}`;
+        }
       };
 
       const allApps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});


### PR DESCRIPTION
- Allow passing `--seed-fork` CLI parameter on launch to add a string to each group seed on import, to prevent source chain forking when using multiple profiles on the same major Moss version.
- Skip wait for sync on import to speed process.
- Skip tool install on import when not progenitor in stewarded group.