### PR TITLE
feat(wdocker): forward-port headless execution support from main (#224)

### DIFF
--- a/tests/src/wdocker/helpers.test.ts
+++ b/tests/src/wdocker/helpers.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const passwordInputMock = vi.fn();
+
+vi.mock('@inquirer/prompts', () => ({
+  password: passwordInputMock,
+}));
+
+vi.mock('../../../wdocker/src/const.js', () => ({
+  GROUP_HAPP_URL: 'https://example.test/group.happ',
+  MOSS_CONFIG: { groupHapp: { sha256: '' } },
+}));
+
+const { getPassword, getInitPassword } = await import('../../../wdocker/src/helpers/helpers.js');
+
+describe('wdocker password helpers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.WDOCKER_PASSWORD;
+  });
+
+  it('uses an explicitly set empty env var as an error instead of prompting', async () => {
+    process.env.WDOCKER_PASSWORD = '';
+    passwordInputMock.mockResolvedValue('prompted');
+
+    await expect(getPassword()).rejects.toThrow('WDOCKER_PASSWORD must be a non-empty value');
+    expect(passwordInputMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the password from the environment when provided', async () => {
+    process.env.WDOCKER_PASSWORD = 'secret';
+    passwordInputMock.mockResolvedValue('prompted');
+
+    const password = await getPassword();
+
+    expect(password).toBe('secret');
+    expect(passwordInputMock).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the environment variable after reading it', async () => {
+    process.env.WDOCKER_PASSWORD = 'secret';
+    passwordInputMock.mockResolvedValue('prompted');
+
+    const password = await getPassword();
+
+    expect(password).toBe('secret');
+    expect(process.env.WDOCKER_PASSWORD).toBeUndefined();
+  });
+
+  it('rejects empty env password during initialization and does not prompt', async () => {
+    process.env.WDOCKER_PASSWORD = '';
+    passwordInputMock.mockResolvedValue('prompted');
+
+    await expect(getInitPassword()).rejects.toThrow('WDOCKER_PASSWORD must be a non-empty value');
+    expect(passwordInputMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/src/wdocker/purge.test.ts
+++ b/tests/src/wdocker/purge.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const confirmMock = vi.fn();
+const rmSyncMock = vi.fn().mockImplementation(() => undefined);
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: confirmMock,
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    rmSync: rmSyncMock,
+  },
+  rmSync: rmSyncMock,
+}));
+
+vi.mock('../../../wdocker/src/const.js', () => ({
+  GROUP_HAPP_URL: 'https://example.test/group.happ',
+  MOSS_CONFIG: { groupHapp: { sha256: '' } },
+  PACKAGE_JSON: { version: '0.0.0' },
+}));
+
+vi.mock('../../../wdocker/src/filesystem.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../wdocker/src/filesystem.js')>(
+    '../../../wdocker/src/filesystem.js',
+  );
+  return {
+    ...actual,
+    WDockerFilesystem: class {
+      constructor() {}
+      conductorExists() {
+        return true;
+      }
+      setConductorId() {}
+      get conductorDataDir() {
+        return '/tmp/conductor';
+      }
+    },
+  };
+});
+
+const { purgeConductor } = await import('../../../wdocker/src/commands/purge.js');
+
+describe('purgeConductor confirmation handling', () => {
+  const conductorId = 'test-conductor';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.WDOCKER_PURGE_CONFIRM;
+  });
+
+  it('aborts when purge confirmation is set to a non-true value', async () => {
+    process.env.WDOCKER_PURGE_CONFIRM = 'false';
+
+    await expect(purgeConductor(conductorId)).resolves.toBeUndefined();
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the conductor without prompting when purge confirmation is set to true', async () => {
+    process.env.WDOCKER_PURGE_CONFIRM = 'true';
+
+    await expect(purgeConductor(conductorId)).resolves.toBeUndefined();
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses interactive confirmation when the env var is not set', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    await expect(purgeConductor(conductorId)).resolves.toBeUndefined();
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wdocker/README.md
+++ b/wdocker/README.md
@@ -4,6 +4,24 @@ CLI to run Moss always-online nodes.
 
 ⚠️ wdocker is not supported on Windows
 
+## Headless / non-interactive usage
+
+wdocker also supports a few environment variables for automation, CI, and container-based setups:
+
+- `WDOCKER_PASSWORD`: supplies the conductor password without prompting. If this variable is set, wdocker will use it for password prompts and initial password creation. The value must be non-empty; whitespace-only values are rejected.
+- `WDOCKER_PROFILE_NAME`: overrides the profile name used when joining a group.
+- `WDOCKER_NODE_DESCRIPTION`: overrides the node description used when joining a group.
+- `WDOCKER_PURGE_CONFIRM`: controls purge confirmation in non-interactive mode. Set it to `true` to skip the confirmation prompt and proceed with purge. Any other value aborts the purge.
+
+Example:
+
+```bash
+WDOCKER_PASSWORD='secret' \
+WDOCKER_PROFILE_NAME='my-node' \
+WDOCKER_NODE_DESCRIPTION='Runs in CI' \
+wdocker join-group my-conductor "[group invite link]"
+```
+
 ## Instructions
 
 0. Install the `wdocker` CLI globally:

--- a/wdocker/src/commands/conductor/join-group.ts
+++ b/wdocker/src/commands/conductor/join-group.ts
@@ -21,14 +21,20 @@ export async function joinGroup(conductorId: string, inviteLink: string): Promis
   wDockerFs.setConductorId(conductorId);
   const password = await getPassword();
   const config = wDockerFs.wdockerConductorConfig;
-  const profileName = await input({
-    message: 'How do you want this node to be named inside the group?',
-    default: config.defaultProfileName,
-  });
-  const wdockerNodeDescription = await input({
-    message: 'Choose a description for this node',
-    default: config.defaultNodeDescription,
-  });
+  const envProfileName = process.env.WDOCKER_PROFILE_NAME;
+  const profileName = envProfileName
+    ? envProfileName
+    : await input({
+        message: 'How do you want this node to be named inside the group?',
+        default: config.defaultProfileName,
+      });
+  const envNodeDescription = process.env.WDOCKER_NODE_DESCRIPTION;
+  const wdockerNodeDescription = envNodeDescription
+    ? envNodeDescription
+    : await input({
+        message: 'Choose a description for this node',
+        default: config.defaultNodeDescription,
+      });
   wDockerFs.setWdockerConductorConfig({
     ...config,
     defaultNodeDescription: wdockerNodeDescription,

--- a/wdocker/src/commands/info.ts
+++ b/wdocker/src/commands/info.ts
@@ -1,5 +1,4 @@
-import { password as passwordInput } from '@inquirer/prompts';
-
+import { getPassword } from '../helpers/helpers.js';
 import { WDockerFilesystem } from '../filesystem.js';
 import { AdminWebsocket } from '@holochain/client';
 
@@ -14,7 +13,7 @@ export async function info(id: string) {
     return;
   }
 
-  const pw = await passwordInput({ message: 'conductor password:' });
+  const pw = await getPassword();
   const runningSecretInfo = wDockerFs.readRunningSecretFile(pw);
   if (!runningSecretInfo) {
     console.log('Failed to connect to conductor. No port file found.');

--- a/wdocker/src/commands/purge.ts
+++ b/wdocker/src/commands/purge.ts
@@ -9,9 +9,22 @@ export async function purgeConductor(conductorId: string) {
     return;
   }
   wDockerFs.setConductorId(conductorId);
-  const confirmed = await confirm({
-    message: `Are you sure you want to delete this whole conductor?\nThis will irreversibly delete all data in ${wDockerFs.conductorDataDir}`,
-  });
+  const envPurgeConfirm = process.env.WDOCKER_PURGE_CONFIRM;
+  let confirmed: boolean;
+
+  if (envPurgeConfirm !== undefined) {
+    if (envPurgeConfirm === 'true') {
+      confirmed = true;
+    } else {
+      console.log('Purge aborted: set WDOCKER_PURGE_CONFIRM=true to confirm non-interactively.');
+      return;
+    }
+  } else {
+    confirmed = await confirm({
+      message: `Are you sure you want to delete this whole conductor?\nThis will irreversibly delete all data in ${wDockerFs.conductorDataDir}`,
+    });
+  }
+
   if (confirmed) {
     fs.rmSync(wDockerFs.conductorDataDir, { recursive: true });
     console.log('Conductor deleted.');

--- a/wdocker/src/daemon/start.ts
+++ b/wdocker/src/daemon/start.ts
@@ -9,10 +9,10 @@ import yaml from 'js-yaml';
 import * as childProcess from 'child_process';
 import { fileURLToPath } from 'url';
 import winston, { createLogger, transports, format } from 'winston';
-import { password as passwordInput } from '@inquirer/prompts';
 
 import { ConductorRunningInfo, RunningSecretInfo, WDockerFilesystem } from '../filesystem.js';
 import { AdminWebsocket } from '@holochain/client';
+import { getInitPassword, getPassword } from '../helpers/helpers.js';
 import {
   CONDUCTOR_CONFIG_TEMPLATE,
   PRODUCTION_BOOTSTRAP_URLS,
@@ -80,16 +80,14 @@ export async function startDaemon(id: string, init: boolean, detached: boolean):
     return;
   }
 
-  let pw;
+  let pw: string | null;
   if (init) {
-    pw = await passwordInput({ message: 'Choose password:' });
-    const pwConfirm = await passwordInput({ message: 'Confirm password:' });
-    if (pw !== pwConfirm) {
-      console.log("Passwords don't match.");
-      return;
-    }
+    pw = await getInitPassword();
   } else {
-    pw = await passwordInput({ message: 'conductor password:' });
+    pw = await getPassword();
+  }
+  if (!pw) {
+    return;
   }
 
   // https://stackoverflow.com/questions/35357853/how-to-close-the-stdio-pipes-of-child-processes-in-node-js
@@ -97,8 +95,11 @@ export async function startDaemon(id: string, init: boolean, detached: boolean):
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
   const daemonScript = path.join(__dirname, 'daemon.js');
+  const sanitizedEnv = { ...process.env };
+  delete sanitizedEnv.WDOCKER_PASSWORD;
   const daemonHandle = childProcess.spawn('node', [daemonScript, id], {
     detached,
+    env: sanitizedEnv,
   });
   daemonHandle.stdin.write(pw);
   daemonHandle.stdin.end();

--- a/wdocker/src/helpers/helpers.ts
+++ b/wdocker/src/helpers/helpers.ts
@@ -21,8 +21,41 @@ import { GROUP_HAPP_URL, MOSS_CONFIG } from '../const.js';
 import { downloadFile, signZomeCall } from '../utils.js';
 import { decode } from '@msgpack/msgpack';
 
+function consumePasswordFromEnv(): string | undefined {
+  const envPassword = process.env.WDOCKER_PASSWORD;
+  if (envPassword === undefined) {
+    return undefined;
+  }
+
+  if (envPassword.trim() === '') {
+    delete process.env.WDOCKER_PASSWORD;
+    throw new Error('WDOCKER_PASSWORD must be a non-empty value when provided.');
+  }
+
+  delete process.env.WDOCKER_PASSWORD;
+  return envPassword;
+}
+
 export async function getPassword(): Promise<string> {
+  const envPassword = consumePasswordFromEnv();
+  if (envPassword) {
+    return envPassword;
+  }
   return passwordInput({ message: 'conductor password:' });
+}
+
+export async function getInitPassword(): Promise<string | null> {
+  const envPassword = consumePasswordFromEnv();
+  if (envPassword) {
+    return envPassword;
+  }
+  const pw = await passwordInput({ message: 'Choose password:' });
+  const pwConfirm = await passwordInput({ message: 'Confirm password:' });
+  if (pw !== pwConfirm) {
+    console.log("Passwords don't match.");
+    return null;
+  }
+  return pw;
 }
 
 export async function getAdminWs(id: string, password: string): Promise<AdminWebsocket> {


### PR DESCRIPTION
Forward-ports #224 (merged to main as 8e72d06d) to main-0.7.

## What

Environment-variable fallbacks so `wdocker` can run headlessly (e.g. driven by the Holo Node Manager backend):

- `WDOCKER_PASSWORD` — consumed on first read, stripped from the daemon child's environment (stdin-only delivery); empty/whitespace values error instead of silently falling back to a prompt that would hang a headless caller.
- `WDOCKER_PROFILE_NAME` / `WDOCKER_NODE_DESCRIPTION` — bypass the join-group prompts.
- `WDOCKER_PURGE_CONFIRM` — fails closed: only `'true'` confirms, any other set value aborts, unset stays interactive.

Plus unit tests for the password helpers and purge confirmation, and README documentation of the headless contract.

## Porting notes

- The affected wdocker files were identical between the branches apart from formatting main-0.7 already had, so this is a clean content port of the merged result — the three files whose PR changes were formatting-only (`const.ts`, `daemon.ts`, `list-groups.ts`) needed no changes here.
- Two empty-brace bodies in `purge.test.ts` were collapsed (`{ }` → `{}`) to keep the file prettier-clean on this branch; this was the one known cosmetic leftover in #224.

## Verification

- All 7 wdocker unit tests pass against the main-0.7 tree.
- All ported files pass `prettier --check` with the repo config.