### PR TITLE
fix(security): scope applet zome-call signing + validate WAL-window origins (Phase 0.5)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -644,9 +644,12 @@ if (!RUNNING_WITH_COMMAND) {
 
     if (!appletCellCache) await rebuildAppletCellCache();
     let decision = evaluate();
-    if (!decision.sign) {
-      // Refresh once before refusing: the cell may belong to an applet or group
-      // installed since the cache was last built.
+    // Refresh once before refusing only when the cell is simply unknown — it may
+    // belong to an applet or group installed since the cache was last built. A
+    // known group cell refused for a non-profiles zome cannot become allowed by
+    // a rebuild, so don't pay a listApps round-trip for those (a misbehaving
+    // applet could otherwise trigger one per rejected call).
+    if (!decision.sign && decision.reason === 'unknown-cell') {
       await rebuildAppletCellCache();
       decision = evaluate();
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -82,6 +82,8 @@ import {
   AppWebsocket,
   CallZomeRequest,
   CallZomeTransform,
+  CellId,
+  CellInfo,
   CellType,
   DnaHashB64,
   InstalledAppId,
@@ -109,11 +111,16 @@ import { type WeRustHandler } from '@lightningrodlabs/we-rust-utils';
 import {
   appletIdFromAppId,
   deriveToolCompatibilityId,
+  getCellId,
   globalPubKeyFromListAppsResponse,
   toLowerCaseB64,
   toolCompatibilityIdFromDistInfo,
   toOriginalCaseB64,
 } from '@theweave/utils';
+import {
+  decideZomeCallSignable,
+  type ZomeCallSigningDecision,
+} from './zomeCallSigningPolicy';
 import { sortVersionsDescending } from './utils';
 import { Profile as AgentProfile } from '@holochain-open-dev/profiles';
 import { Jimp } from 'jimp';
@@ -559,8 +566,102 @@ if (!RUNNING_WITH_COMMAND) {
     return signZomeCall(zomeCall, WE_RUST_HANDLER, WE_EMITTER);
   };
 
-  const handleSignZomeCallApplet = (_e: IpcMainInvokeEvent, zomeCall: CallZomeRequest) => {
+  // Stable string key for a CellId ([DnaHash, AgentPubKey]) so it can go in a Set.
+  const cellIdKey = (cellId: CellId): string =>
+    `${encodeHashToBase64(cellId[0])}|${encodeHashToBase64(cellId[1])}`;
+
+  const cellIdsOfApp = (appInfo: AppInfo, roleFilter?: string): string[] => {
+    const keys: string[] = [];
+    for (const [roleName, cellInfos] of Object.entries(appInfo.cell_info)) {
+      if (roleFilter && roleName !== roleFilter) continue;
+      for (const cellInfo of cellInfos as CellInfo[]) {
+        const cellId = getCellId(cellInfo);
+        if (cellId) keys.push(cellIdKey(cellId));
+      }
+    }
+    return keys;
+  };
+
+  // Cache of the cells an applet is allowed to have signed. Resolving these means
+  // a listApps round-trip, and signing is on the hot path, so results are cached
+  // and only rebuilt on a cache miss that is old enough to be worth re-checking
+  // (which is what makes a just-installed app's cells become known).
+  const APPLET_CELL_CACHE_MIN_REBUILD_MS = 3000;
+  let appletCellCache:
+    | { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string>; builtAt: number }
+    | undefined;
+
+  const rebuildAppletCellCache = async (): Promise<void> => {
+    const apps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
+    const ownByAppletId = new Map<string, Set<string>>();
+    const groupCells = new Set<string>();
+    for (const app of apps) {
+      const appId = app.installed_app_id;
+      if (appId.startsWith('applet#')) {
+        ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
+      } else if (appId.startsWith('group#')) {
+        // Only the `group` role cell hosts the profiles zome an applet may call.
+        for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+      }
+    }
+    appletCellCache = { ownByAppletId, groupCells, builtAt: Date.now() };
+  };
+
+  // The union of own-cells across the caller's applet ids. A plain applet caller
+  // passes one id; a cross-group view passes every applet of its tool, so it may
+  // legitimately sign for any of them (but still only their own cells).
+  const ownCellsForCallers = (callerAppletIds: AppletId[]): Set<string> => {
+    const union = new Set<string>();
+    for (const id of callerAppletIds) {
+      for (const key of appletCellCache?.ownByAppletId.get(id) ?? []) union.add(key);
+    }
+    return union;
+  };
+
+  // Decide whether to sign, rebuilding the cache once if a first look says no —
+  // covers the case where the applet or a group was installed since the last build.
+  const authorizeAppletZomeCall = async (
+    callerAppletIds: AppletId[],
+    zomeCall: CallZomeRequest,
+  ): Promise<ZomeCallSigningDecision> => {
+    if (!zomeCall.cell_id) return { sign: false, reason: 'unknown-cell' };
+    const evaluate = (): ZomeCallSigningDecision =>
+      decideZomeCallSignable({
+        cellIdB64: cellIdKey(zomeCall.cell_id!),
+        zomeName: zomeCall.zome_name,
+        appletOwnCellIdsB64: ownCellsForCallers(callerAppletIds),
+        groupCellIdsB64: appletCellCache?.groupCells ?? new Set(),
+      });
+
+    if (!appletCellCache) await rebuildAppletCellCache();
+    let decision = evaluate();
+    if (
+      !decision.sign &&
+      appletCellCache &&
+      Date.now() - appletCellCache.builtAt > APPLET_CELL_CACHE_MIN_REBUILD_MS
+    ) {
+      await rebuildAppletCellCache();
+      decision = evaluate();
+    }
+    return decision;
+  };
+
+  const handleSignZomeCallApplet = async (
+    _e: IpcMainInvokeEvent,
+    zomeCall: CallZomeRequest,
+    callerAppletIds: AppletId[],
+  ) => {
     if (!WE_RUST_HANDLER) throw Error('Rust handler is not ready');
+    if (!HOLOCHAIN_MANAGER) throw Error('Holochain manager is not ready');
+    if (!Array.isArray(callerAppletIds) || callerAppletIds.length === 0)
+      throw Error('sign-zome-call-applet requires the requesting applet id(s).');
+
+    const decision = await authorizeAppletZomeCall(callerAppletIds, zomeCall);
+    if (!decision.sign) {
+      throw Error(
+        `Refusing to sign zome call for applet(s) ${callerAppletIds.join(', ')}: ${decision.reason}. An applet may only sign calls to its own cells and to the profiles zome of a group cell.`,
+      );
+    }
     return signZomeCall(zomeCall, WE_RUST_HANDLER, WE_EMITTER);
   };
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -583,28 +583,37 @@ if (!RUNNING_WITH_COMMAND) {
   };
 
   // Cache of the cells an applet is allowed to have signed. Resolving these means
-  // a listApps round-trip, and signing is on the hot path, so results are cached
-  // and only rebuilt on a cache miss that is old enough to be worth re-checking
-  // (which is what makes a just-installed app's cells become known).
-  const APPLET_CELL_CACHE_MIN_REBUILD_MS = 3000;
+  // a listApps round-trip, and signing is on the hot path, so results are cached.
+  // A miss (the decision below says "no") always refreshes once before the call
+  // is refused, so a just-installed applet or group is picked up immediately with
+  // no false rejection; concurrent refreshes are coalesced into one listApps.
   let appletCellCache:
-    | { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string>; builtAt: number }
+    | { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string> }
     | undefined;
+  let cacheRebuildInFlight: Promise<void> | undefined;
 
-  const rebuildAppletCellCache = async (): Promise<void> => {
-    const apps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
-    const ownByAppletId = new Map<string, Set<string>>();
-    const groupCells = new Set<string>();
-    for (const app of apps) {
-      const appId = app.installed_app_id;
-      if (appId.startsWith('applet#')) {
-        ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
-      } else if (appId.startsWith('group#')) {
-        // Only the `group` role cell hosts the profiles zome an applet may call.
-        for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+  const rebuildAppletCellCache = (): Promise<void> => {
+    if (cacheRebuildInFlight) return cacheRebuildInFlight;
+    cacheRebuildInFlight = (async () => {
+      try {
+        const apps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
+        const ownByAppletId = new Map<string, Set<string>>();
+        const groupCells = new Set<string>();
+        for (const app of apps) {
+          const appId = app.installed_app_id;
+          if (appId.startsWith('applet#')) {
+            ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
+          } else if (appId.startsWith('group#')) {
+            // Only the `group` role cell hosts the profiles zome an applet may call.
+            for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+          }
+        }
+        appletCellCache = { ownByAppletId, groupCells };
+      } finally {
+        cacheRebuildInFlight = undefined;
       }
-    }
-    appletCellCache = { ownByAppletId, groupCells, builtAt: Date.now() };
+    })();
+    return cacheRebuildInFlight;
   };
 
   // The union of own-cells across the caller's applet ids. A plain applet caller
@@ -635,11 +644,9 @@ if (!RUNNING_WITH_COMMAND) {
 
     if (!appletCellCache) await rebuildAppletCellCache();
     let decision = evaluate();
-    if (
-      !decision.sign &&
-      appletCellCache &&
-      Date.now() - appletCellCache.builtAt > APPLET_CELL_CACHE_MIN_REBUILD_MS
-    ) {
+    if (!decision.sign) {
+      // Refresh once before refusing: the cell may belong to an applet or group
+      // installed since the cache was last built.
       await rebuildAppletCellCache();
       decision = evaluate();
     }

--- a/src/main/zomeCallSigningPolicy.test.ts
+++ b/src/main/zomeCallSigningPolicy.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { decideZomeCallSignable, type ZomeCallSigningInput } from './zomeCallSigningPolicy';
+
+const OWN_A = 'own-cell-a';
+const OWN_B = 'own-cell-b';
+const GROUP_1 = 'group-cell-1';
+const GROUP_2 = 'group-cell-2';
+const FOREIGN = 'some-other-cell';
+
+function input(overrides: Partial<ZomeCallSigningInput>): ZomeCallSigningInput {
+  return {
+    cellIdB64: OWN_A,
+    zomeName: 'posts',
+    appletOwnCellIdsB64: new Set([OWN_A, OWN_B]),
+    groupCellIdsB64: new Set([GROUP_1, GROUP_2]),
+    ...overrides,
+  };
+}
+
+describe('decideZomeCallSignable', () => {
+  const rows: Array<{
+    name: string;
+    cellIdB64: string;
+    zomeName: string;
+    expected: ReturnType<typeof decideZomeCallSignable>;
+  }> = [
+    {
+      name: 'own cell, any zome → sign',
+      cellIdB64: OWN_A,
+      zomeName: 'posts',
+      expected: { sign: true, reason: 'own-cell' },
+    },
+    {
+      name: 'second own cell, any zome → sign',
+      cellIdB64: OWN_B,
+      zomeName: 'whatever',
+      expected: { sign: true, reason: 'own-cell' },
+    },
+    {
+      name: 'own cell wins even for a zome named "profiles"',
+      cellIdB64: OWN_A,
+      zomeName: 'profiles',
+      expected: { sign: true, reason: 'own-cell' },
+    },
+    {
+      name: 'group cell + profiles zome → sign',
+      cellIdB64: GROUP_1,
+      zomeName: 'profiles',
+      expected: { sign: true, reason: 'group-profiles' },
+    },
+    {
+      name: 'any installed group cell + profiles → sign',
+      cellIdB64: GROUP_2,
+      zomeName: 'profiles',
+      expected: { sign: true, reason: 'group-profiles' },
+    },
+    {
+      name: 'group cell + group zome → REJECT (the core vulnerability)',
+      cellIdB64: GROUP_1,
+      zomeName: 'group',
+      expected: { sign: false, reason: 'group-zome-not-allowed' },
+    },
+    {
+      name: 'group cell + custom_views → REJECT',
+      cellIdB64: GROUP_1,
+      zomeName: 'custom_views',
+      expected: { sign: false, reason: 'group-zome-not-allowed' },
+    },
+    {
+      name: 'group cell + peer_status → REJECT (delivered via host events, not direct calls)',
+      cellIdB64: GROUP_1,
+      zomeName: 'peer_status',
+      expected: { sign: false, reason: 'group-zome-not-allowed' },
+    },
+    {
+      name: 'unknown cell + profiles → REJECT (only known group cells get the profiles allowance)',
+      cellIdB64: FOREIGN,
+      zomeName: 'profiles',
+      expected: { sign: false, reason: 'unknown-cell' },
+    },
+    {
+      name: 'unknown cell + arbitrary zome → REJECT',
+      cellIdB64: FOREIGN,
+      zomeName: 'group',
+      expected: { sign: false, reason: 'unknown-cell' },
+    },
+  ];
+
+  for (const row of rows) {
+    it(row.name, () => {
+      expect(
+        decideZomeCallSignable(input({ cellIdB64: row.cellIdB64, zomeName: row.zomeName })),
+      ).toEqual(row.expected);
+    });
+  }
+
+  it('an applet with no resolved cells signs nothing', () => {
+    expect(
+      decideZomeCallSignable({
+        cellIdB64: OWN_A,
+        zomeName: 'posts',
+        appletOwnCellIdsB64: new Set(),
+        groupCellIdsB64: new Set(),
+      }),
+    ).toEqual({ sign: false, reason: 'unknown-cell' });
+  });
+});

--- a/src/main/zomeCallSigningPolicy.ts
+++ b/src/main/zomeCallSigningPolicy.ts
@@ -1,0 +1,59 @@
+/**
+ * Authorization for applet-requested zome-call signing.
+ *
+ * An applet iframe cannot sign its own zome calls — it has no access to lair —
+ * so every call it makes is signed on demand by the host. Signing must therefore
+ * be scoped to what the applet is legitimately allowed to call, otherwise a Tool
+ * installed by the user inherits the user's full authority on every app whose
+ * auth token the applet holds (notably the group app, whose token is handed to
+ * the applet so it can read/write profiles).
+ *
+ * The legitimate signing surface for an applet is exactly:
+ *   - any zome in one of the applet's OWN cells, and
+ *   - the `profiles` zome in a group cell (the only group-app zome an applet
+ *     calls directly; everything else — assets, peer status, remote signals —
+ *     goes through the host bridge, which applies its own scoping).
+ *
+ * This decision is a pure function of already-encoded identifiers so it can be
+ * table-tested without a conductor. The host resolves the allowed cell-id sets
+ * from live app info and feeds them in.
+ */
+
+/** The one group-app zome an applet is permitted to have signed directly. */
+export const APPLET_ALLOWED_GROUP_ZOME = 'profiles';
+
+export interface ZomeCallSigningInput {
+  /** base64-encoded CellId of the call's target cell. */
+  cellIdB64: string;
+  /** The zome the call targets. */
+  zomeName: string;
+  /** base64 CellIds belonging to the requesting applet's own installed app. */
+  appletOwnCellIdsB64: ReadonlySet<string>;
+  /** base64 CellIds of the group-role cells the user has installed. */
+  groupCellIdsB64: ReadonlySet<string>;
+}
+
+export type ZomeCallSigningDecision =
+  | { sign: true; reason: 'own-cell' | 'group-profiles' }
+  | { sign: false; reason: 'unknown-cell' | 'group-zome-not-allowed' };
+
+export function decideZomeCallSignable(input: ZomeCallSigningInput): ZomeCallSigningDecision {
+  const { cellIdB64, zomeName, appletOwnCellIdsB64, groupCellIdsB64 } = input;
+
+  // The applet's own cells: any zome is fair game — this is the applet's own DNA.
+  if (appletOwnCellIdsB64.has(cellIdB64)) {
+    return { sign: true, reason: 'own-cell' };
+  }
+
+  // A group cell: only the profiles zome. The group cell also hosts the group,
+  // custom_views and peer_status zomes, which an applet must never drive, so the
+  // check is (cell, zome)-aware — cell membership alone is not sufficient.
+  if (groupCellIdsB64.has(cellIdB64)) {
+    if (zomeName === APPLET_ALLOWED_GROUP_ZOME) {
+      return { sign: true, reason: 'group-profiles' };
+    }
+    return { sign: false, reason: 'group-zome-not-allowed' };
+  }
+
+  return { sign: false, reason: 'unknown-cell' };
+}

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -31,8 +31,8 @@ contextBridge.exposeInMainWorld('__HC_ZOME_CALL_SIGNER__', {
 });
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  signZomeCallApplet: (request: CallZomeRequest) =>
-    ipcRenderer.invoke('sign-zome-call-applet', request),
+  signZomeCallApplet: (request: CallZomeRequest, callerAppletIds: string[]) =>
+    ipcRenderer.invoke('sign-zome-call-applet', request, callerAppletIds),
   appletMessageToParentResponse: (response: any, id: string) =>
     ipcRenderer.invoke('applet-message-to-parent-response', response, id),
   parentToAppletMessage: (message: ParentToAppletMessage, forApplet: AppletId) =>

--- a/src/preload/walwindow.ts
+++ b/src/preload/walwindow.ts
@@ -31,8 +31,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   selectScreenOrWindow: () => ipcRenderer.invoke('select-screen-or-window'),
   setMyIcon: (icon: string) => ipcRenderer.invoke('set-my-icon', icon),
   setMyTitle: (title: string) => ipcRenderer.invoke('set-my-title', title),
-  signZomeCallApplet: (request: CallZomeRequest) =>
-    ipcRenderer.invoke('sign-zome-call-applet', request),
+  signZomeCallApplet: (request: CallZomeRequest, callerAppletIds: string[]) =>
+    ipcRenderer.invoke('sign-zome-call-applet', request, callerAppletIds),
 });
 
 declare global {

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -698,8 +698,20 @@ export async function handleAppletIframeMessage(
       const appletAgents = await groupStore!.groupClient.getJoinedAppletAgents(appletHash);
       return appletAgents.map((appletAgent) => appletAgent.applet_pubkey);
     }
-    case 'sign-zome-call':
-      return signZomeCallApplet(message.request);
+    case 'sign-zome-call': {
+      // Scope signing to the requesting iframe's real identity (derived from its
+      // origin, above). An applet may sign for its own cells; a cross-group view
+      // may sign for any applet of the tool it aggregates. The host refuses
+      // anything else, so the group app token an applet holds cannot be used to
+      // drive the group/custom_views/foyer/assets zomes.
+      const callerAppletIds =
+        source.type === 'applet'
+          ? [encodeHashToBase64(source.appletHash)]
+          : Object.keys(
+              await toPromise(mossStore.appletsForToolId.get(source.toolCompatibilityId)),
+            );
+      return signZomeCallApplet(message.request, callerAppletIds);
+    }
     case 'log-zome-call':
       mossStore.logZomeCall({
         info: {

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -47,7 +47,10 @@ declare global {
       signZomeCall: (request: CallZomeRequest) => Promise<CallZomeRequestSigned>;
     };
     electronAPI: {
-      signZomeCallApplet: (request: CallZomeRequest) => Promise<CallZomeRequestSigned>;
+      signZomeCallApplet: (
+        request: CallZomeRequest,
+        callerAppletIds: string[],
+      ) => Promise<CallZomeRequestSigned>;
       appletMessageToParentResponse: (response: any, id: string) => Promise<void>;
       parentToAppletMessage: (
         message: ParentToAppletMessage,
@@ -425,8 +428,11 @@ export async function validateHappOrWebhapp(bytes: number[]) {
   return window.electronAPI.validateHappOrWebhapp(bytes);
 }
 
-export const signZomeCallApplet = async (request: CallZomeRequest) => {
-  return window.electronAPI.signZomeCallApplet(request);
+export const signZomeCallApplet = async (
+  request: CallZomeRequest,
+  callerAppletIds: string[],
+) => {
+  return window.electronAPI.signZomeCallApplet(request, callerAppletIds);
 };
 
 // Dev UI Override

--- a/src/renderer/src/wal-message-source.test.ts
+++ b/src/renderer/src/wal-message-source.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { deriveWalMessageSource } from './wal-message-source';
+import type { IframeKind } from '@theweave/api';
+
+const APPLET_HASH = new Uint8Array([1, 2, 3]);
+const IFRAME_GROUP = new Uint8Array([9, 9, 9]);
+const FALLBACK_GROUP = new Uint8Array([7, 7, 7]);
+
+describe('deriveWalMessageSource', () => {
+  it('applet iframe keeps its own declared groupHash', () => {
+    const kind: IframeKind = {
+      type: 'applet',
+      appletHash: APPLET_HASH,
+      groupHash: IFRAME_GROUP,
+      subType: 'main',
+    };
+    expect(deriveWalMessageSource(kind, 'asset', FALLBACK_GROUP)).toEqual({
+      type: 'applet',
+      appletHash: APPLET_HASH,
+      groupHash: IFRAME_GROUP,
+      subType: 'asset',
+    });
+  });
+
+  it('applet iframe with no declared groupHash falls back to the WAL window group', () => {
+    const kind: IframeKind = {
+      type: 'applet',
+      appletHash: APPLET_HASH,
+      groupHash: null,
+      subType: 'main',
+    };
+    expect(deriveWalMessageSource(kind, 'main', FALLBACK_GROUP)).toEqual({
+      type: 'applet',
+      appletHash: APPLET_HASH,
+      groupHash: FALLBACK_GROUP,
+      subType: 'main',
+    });
+  });
+
+  it('cross-group iframe carries the tool id and never a groupHash', () => {
+    const kind: IframeKind = {
+      type: 'cross-group',
+      toolCompatibilityId: 'tool-xyz',
+      subType: 'main',
+    };
+    expect(deriveWalMessageSource(kind, 'creatable', FALLBACK_GROUP)).toEqual({
+      type: 'cross-group',
+      toolCompatibilityId: 'tool-xyz',
+      subType: 'creatable',
+    });
+  });
+
+  it('uses the passed subType, not the identity subType', () => {
+    const kind: IframeKind = {
+      type: 'applet',
+      appletHash: APPLET_HASH,
+      groupHash: IFRAME_GROUP,
+      subType: 'main',
+    };
+    expect(deriveWalMessageSource(kind, 'block', FALLBACK_GROUP).subType).toBe('block');
+  });
+});

--- a/src/renderer/src/wal-message-source.ts
+++ b/src/renderer/src/wal-message-source.ts
@@ -1,0 +1,32 @@
+import { IframeKind } from '@theweave/api';
+import { DnaHash } from '@holochain/client';
+
+/**
+ * The `source` a WAL window stamps on a message it forwards to the main process
+ * on behalf of an embedded iframe.
+ *
+ * The identity (`iframeKind`) MUST come from the iframe's origin, never from the
+ * forwarded message — that is the trust boundary. This function only assembles
+ * the source object from that already-derived identity, so it is a pure,
+ * table-testable expression with no DOM coupling. `fallbackGroupHash` is the WAL
+ * window's own group, used only when an applet iframe did not declare one.
+ */
+export function deriveWalMessageSource(
+  iframeKind: IframeKind,
+  subType: string,
+  fallbackGroupHash: DnaHash,
+): IframeKind {
+  if (iframeKind.type === 'cross-group') {
+    return {
+      type: 'cross-group',
+      toolCompatibilityId: iframeKind.toolCompatibilityId,
+      subType,
+    };
+  }
+  return {
+    type: 'applet',
+    appletHash: iframeKind.appletHash,
+    groupHash: iframeKind.groupHash ?? fallbackGroupHash,
+    subType,
+  };
+}

--- a/src/renderer/src/walwindow.ts
+++ b/src/renderer/src/walwindow.ts
@@ -65,7 +65,10 @@ declare global {
       selectScreenOrWindow: () => Promise<string>;
       setMyIcon: (icon: string) => Promise<void>;
       setMyTitle: (title: string) => Promise<void>;
-      signZomeCallApplet: (request: CallZomeRequest) => Promise<CallZomeRequestSigned>;
+      signZomeCallApplet: (
+        request: CallZomeRequest,
+        callerAppletIds: string[],
+      ) => Promise<CallZomeRequestSigned>;
     };
   }
 }

--- a/src/renderer/src/walwindow.ts
+++ b/src/renderer/src/walwindow.ts
@@ -165,23 +165,47 @@ export class WalWindow extends LitElement {
       const request = message.data;
 
       const handleRequest = async (request: AppletToParentMessage) => {
+        if (this.isAppletDev === undefined) return;
+        // Derive the sender's identity from its iframe origin rather than trusting
+        // the message or assuming it is this window's own applet. An unrecognized
+        // origin is not processed — the same trust boundary the main window
+        // enforces via getIframeKind.
+        const iframeKind = getIframeKind(message, this.isAppletDev);
+        if (!iframeKind) {
+          throw new Error('Ignoring WAL-window message from an unrecognized iframe origin.');
+        }
+        const derivedSource: AppletToParentMessage['source'] =
+          iframeKind.type === 'cross-group'
+            ? {
+                type: 'cross-group',
+                toolCompatibilityId: iframeKind.toolCompatibilityId,
+                subType: request.source.subType,
+              }
+            : {
+                type: 'applet',
+                appletHash: iframeKind.appletHash,
+                groupHash: iframeKind.groupHash ?? this.groupHash!,
+                subType: request.source.subType,
+              };
+
         const handleDefault = () => {
-          const appletToParentMessage: AppletToParentMessage = {
+          return walWindow.electronAPI.appletMessageToParent({
             request: request.request,
-            source: {
-              type: 'applet',
-              appletHash: this.appletHash!,
-              groupHash: this.groupHash!,
-              subType: request.source.subType,
-            },
-          };
-          // console.log('Sending AppletToParentMessage: ', appletToParentMessage);
-          return walWindow.electronAPI.appletMessageToParent(appletToParentMessage);
+            source: derivedSource,
+          });
         };
         if (request) {
           switch (request.request.type) {
-            case 'sign-zome-call':
-              return window.electronAPI.signZomeCallApplet(request.request.request);
+            case 'sign-zome-call': {
+              if (iframeKind.type !== 'applet') {
+                throw new Error(
+                  'Signing zome calls from a cross-group iframe is not supported in a WAL window.',
+                );
+              }
+              return window.electronAPI.signZomeCallApplet(request.request.request, [
+                encodeHashToBase64(iframeKind.appletHash),
+              ]);
+            }
             case 'user-select-screen':
               return window.electronAPI.selectScreenOrWindow();
             case 'request-close':
@@ -192,12 +216,7 @@ export class WalWindow extends LitElement {
               let response;
               const appletToParentMessage: AppletToParentMessage = {
                 request: message.data.request,
-                source: {
-                  type: 'applet',
-                  appletHash: this.appletHash!,
-                  groupHash: this.groupHash!,
-                  subType: request.source.subType,
-                },
+                source: derivedSource,
               };
               try {
                 response = await walWindow.electronAPI.appletMessageToParent(appletToParentMessage);
@@ -214,12 +233,7 @@ export class WalWindow extends LitElement {
               let response;
               const appletToParentMessage: AppletToParentMessage = {
                 request: message.data.request,
-                source: {
-                  type: 'applet',
-                  appletHash: this.appletHash!,
-                  groupHash: this.groupHash!,
-                  subType: request.source.subType,
-                },
+                source: derivedSource,
               };
               try {
                 response = await walWindow.electronAPI.appletMessageToParent(appletToParentMessage);

--- a/src/renderer/src/walwindow.ts
+++ b/src/renderer/src/walwindow.ts
@@ -174,7 +174,17 @@ export class WalWindow extends LitElement {
       // origin is unrecognised. Skipping (rather than replying) keeps such a
       // message from resolving as a spurious `{ success, undefined }`.
       if (this.isAppletDev === undefined) return;
-      const iframeKind = getIframeKind(message, this.isAppletDev);
+      // getIframeKind throws for an origin matching none of its branches (e.g. an
+      // embedded remote iframe). Fail closed and log, rather than letting it
+      // escape the async listener as an unhandled rejection (the main window
+      // catches this in its own try/catch).
+      let iframeKind: ReturnType<typeof getIframeKind>;
+      try {
+        iframeKind = getIframeKind(message, this.isAppletDev);
+      } catch (e) {
+        console.warn('WAL window: ignoring message from an unrecognized iframe origin.', e);
+        return;
+      }
       if (!iframeKind) return;
 
       const handleRequest = async (request: AppletToParentMessage) => {

--- a/src/renderer/src/walwindow.ts
+++ b/src/renderer/src/walwindow.ts
@@ -25,6 +25,7 @@ import { localized, msg } from '@lit/localize';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import { IframeStore } from './iframe-store';
 import { getIframeKind } from './applets/applet-host';
+import { deriveWalMessageSource } from './wal-message-source';
 
 // import { ipcRenderer } from 'electron';
 
@@ -167,29 +168,21 @@ export class WalWindow extends LitElement {
     window.addEventListener('message', async (message: MessageEvent<AppletToParentMessage>) => {
       const request = message.data;
 
+      // Derive the sender's identity from its iframe origin — never from the
+      // message — and, like the main window's `if (!receivedFromSource) return`,
+      // skip without responding when the window is not yet initialised or the
+      // origin is unrecognised. Skipping (rather than replying) keeps such a
+      // message from resolving as a spurious `{ success, undefined }`.
+      if (this.isAppletDev === undefined) return;
+      const iframeKind = getIframeKind(message, this.isAppletDev);
+      if (!iframeKind) return;
+
       const handleRequest = async (request: AppletToParentMessage) => {
-        if (this.isAppletDev === undefined) return;
-        // Derive the sender's identity from its iframe origin rather than trusting
-        // the message or assuming it is this window's own applet. An unrecognized
-        // origin is not processed — the same trust boundary the main window
-        // enforces via getIframeKind.
-        const iframeKind = getIframeKind(message, this.isAppletDev);
-        if (!iframeKind) {
-          throw new Error('Ignoring WAL-window message from an unrecognized iframe origin.');
-        }
-        const derivedSource: AppletToParentMessage['source'] =
-          iframeKind.type === 'cross-group'
-            ? {
-                type: 'cross-group',
-                toolCompatibilityId: iframeKind.toolCompatibilityId,
-                subType: request.source.subType,
-              }
-            : {
-                type: 'applet',
-                appletHash: iframeKind.appletHash,
-                groupHash: iframeKind.groupHash ?? this.groupHash!,
-                subType: request.source.subType,
-              };
+        const derivedSource = deriveWalMessageSource(
+          iframeKind,
+          request.source.subType,
+          this.groupHash!,
+        );
 
         const handleDefault = () => {
           return walWindow.electronAPI.appletMessageToParent({
@@ -248,72 +241,41 @@ export class WalWindow extends LitElement {
               return response;
             }
             case 'get-iframe-config': {
-              if (this.isAppletDev === undefined) return;
-              const iframeKind = getIframeKind(message, this.isAppletDev);
-              if (!iframeKind) return;
               if (iframeKind.type === 'cross-group') {
                 this.iframeStore.registerCrossGroupIframe(iframeKind.toolCompatibilityId, {
                   id: request.request.id,
                   subType: request.request.subType,
                   source: message.source,
                 });
-                return walWindow.electronAPI.appletMessageToParent({
-                  request: request.request,
-                  source: {
-                    type: 'cross-group',
-                    toolCompatibilityId: iframeKind.toolCompatibilityId,
-                    subType: request.source.subType,
-                  },
-                });
               } else {
-                const appletId = encodeHashToBase64(iframeKind.appletHash);
-                this.iframeStore.registerAppletIframe(appletId, {
+                this.iframeStore.registerAppletIframe(encodeHashToBase64(iframeKind.appletHash), {
                   id: request.request.id,
                   subType: request.request.subType,
                   source: message.source,
                 });
-                // Use the child iframe's applet identity, not the parent window's
-                return walWindow.electronAPI.appletMessageToParent({
-                  request: request.request,
-                  source: {
-                    type: 'applet',
-                    appletHash: iframeKind.appletHash,
-                    groupHash: iframeKind.groupHash ?? this.groupHash!,
-                    subType: request.source.subType,
-                  },
-                });
               }
+              // Forward under the child iframe's own identity, not this window's.
+              return walWindow.electronAPI.appletMessageToParent({
+                request: request.request,
+                source: derivedSource,
+              });
             }
             case 'unregister-iframe': {
-              if (this.isAppletDev === undefined) return;
-              const iframeKind = getIframeKind(message, this.isAppletDev);
-              if (!iframeKind) return;
               if (iframeKind.type === 'cross-group') {
                 this.iframeStore.unregisterCrossGroupIframe(
                   iframeKind.toolCompatibilityId,
                   request.request.id,
                 );
-                return walWindow.electronAPI.appletMessageToParent({
-                  request: request.request,
-                  source: {
-                    type: 'cross-group',
-                    toolCompatibilityId: iframeKind.toolCompatibilityId,
-                    subType: request.source.subType,
-                  },
-                });
               } else {
-                const appletId = encodeHashToBase64(iframeKind.appletHash);
-                this.iframeStore.unregisterAppletIframe(appletId, request.request.id);
-                return walWindow.electronAPI.appletMessageToParent({
-                  request: request.request,
-                  source: {
-                    type: 'applet',
-                    appletHash: iframeKind.appletHash,
-                    groupHash: iframeKind.groupHash ?? this.groupHash!,
-                    subType: request.source.subType,
-                  },
-                });
+                this.iframeStore.unregisterAppletIframe(
+                  encodeHashToBase64(iframeKind.appletHash),
+                  request.request.id,
+                );
               }
+              return walWindow.electronAPI.appletMessageToParent({
+                request: request.request,
+                source: derivedSource,
+              });
             }
 
             default:

--- a/tests/e2e/smoke/12.applet-zome-call-roundtrip.spec.ts
+++ b/tests/e2e/smoke/12.applet-zome-call-roundtrip.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, launchMoss, closeMoss } from '../fixtures/moss';
+import { startFreshIfLegacyImport, waitForBoot } from '../helpers/bootToReady';
+import { createGroupFromMainDashboard, enterSpaceIfPrompted } from '../helpers/groups';
+import { installToolFromLibrary, openToolInGroup, waitForAppletHandshake } from '../helpers/tools';
+import { FIXTURE_TOOL_TITLE } from '../fixtures/toolCuration';
+
+/**
+ * Smoke #12 — An applet's own zome calls round-trip through the host signer.
+ *
+ * why: the handshake (#5) proves get-iframe-config + WeaveClient wiring, but it
+ * does NOT go through sign-zome-call-applet — the token handout and postMessage
+ * carry it. This test drives an actual applet zome call: create a post in the
+ * example applet, which signs `create_post` and then reads it back via
+ * `get_all_posts`, both to the applet's OWN cell. It is the smallest assertion
+ * that the host's per-applet signing scope permits an applet's legitimate calls
+ * (regression guard for the trust-boundary signing change). A post-summary only
+ * appears if both signed calls succeeded.
+ */
+const GROUP_NAME = 'Signing Roundtrip';
+const POST_TITLE = `pw-post-${Date.now()}`;
+
+test('applet own-cell zome calls (create_post + get_all_posts) round-trip via the host signer', async ({
+  toolCurationServer,
+  bootstrapSrv,
+}) => {
+  test.setTimeout(360_000);
+
+  const moss = await launchMoss({
+    profileName: `pw-signing-${Date.now()}`,
+    toolCurationUrl: toolCurationServer.curationUrl,
+    bootstrap: bootstrapSrv,
+  });
+
+  try {
+    await waitForBoot(moss.mainWindow, 90_000);
+    await startFreshIfLegacyImport(moss.mainWindow);
+    await createGroupFromMainDashboard(moss.mainWindow, { name: GROUP_NAME });
+    await enterSpaceIfPrompted(moss.mainWindow, 'agent-one');
+
+    await installToolFromLibrary(moss.mainWindow, {
+      toolName: FIXTURE_TOOL_TITLE,
+      groupName: GROUP_NAME,
+    });
+
+    const frame = await openToolInGroup(moss.mainWindow, FIXTURE_TOOL_TITLE);
+    await waitForAppletHandshake(frame, 60_000);
+    await expect(frame.locator('example-applet-main')).toBeVisible({ timeout: 30_000 });
+
+    // Before creating anything the list shows its empty placeholder — confirms
+    // the initial get_all_posts (also a signed own-cell call) succeeded rather
+    // than erroring.
+    await expect(frame.locator('all-posts')).toBeVisible({ timeout: 30_000 });
+
+    // Fill and submit the create-post form. Shoelace form controls live in
+    // nested shadow roots; set their values directly and submit the form (the
+    // same evaluate-based technique the profile helper uses), which fires the
+    // onSubmit handler -> create_post zome call.
+    await frame.locator('create-post').evaluate(
+      async (el: any, { title, content }: { title: string; content: string }) => {
+        const root: ShadowRoot = el.shadowRoot;
+        const titleEl: any = root.querySelector('sl-input[name="title"]');
+        const contentEl: any = root.querySelector('sl-textarea[name="content"]');
+        if (!titleEl || !contentEl) throw new Error('create-post form controls not found');
+        titleEl.value = title;
+        contentEl.value = content;
+        if (titleEl.updateComplete) await titleEl.updateComplete;
+        if (contentEl.updateComplete) await contentEl.updateComplete;
+        const form = root.querySelector('#create-form') as HTMLFormElement | null;
+        if (!form) throw new Error('#create-form not found');
+        form.requestSubmit();
+      },
+      { title: POST_TITLE, content: 'created by e2e signing round-trip test' },
+    );
+
+    // A post-summary renders only after create_post succeeds AND the reloaded
+    // get_all_posts returns the record — both signed via sign-zome-call-applet.
+    await expect(frame.locator('post-summary').first()).toBeVisible({ timeout: 60_000 });
+  } finally {
+    await closeMoss(moss);
+  }
+});


### PR DESCRIPTION
## What this fixes

Two holes on the applet↔host trust boundary (Phase 0.5 of the maintainability plan).

**1. `sign-zome-call-applet` was unscoped.** The host signed any `(cell, zome, fn)` an applet asked for, and applets are handed the group app's auth token (for profiles access). Because a Holochain token authenticates the whole app, an installed Tool could open a websocket to the group app and drive `group` / `custom_views` / `foyer` / `assets` with the user's authority (registering tools, rewriting group metadata, reading private entries, writing asset relations). Since an applet cannot self-sign (no lair access), **scoping the signer closes the hole** without the harder per-app-token capability work.

**2. The WAL popout window had no origin validation.** It stamped every message as its own applet, and its sign path signed before any identity was established, so an embedded iframe (including a remote `https://` one) could get calls signed and misattributed.

## Approach

- `decideZomeCallSignable` (`src/main/zomeCallSigningPolicy.ts`) — pure, table-tested: sign **iff** the target is one of the applet's own cells (any zome) **or** a group cell's `profiles` zome. Everything else an applet does (assets, peer status, remote signals) already goes through the host bridge, which applies its own scoping.
- Enforced in the main process (`handleSignZomeCallApplet`), which resolves + caches the allowed cell sets from live app info. The caller's applet id(s) are passed in, **derived from the requesting iframe's origin** (a cross-group view passes every applet of its tool). Moss's own signer (`sign-zome-call`) is unchanged.
- The WAL window now derives identity via `getIframeKind`, drops messages from unrecognized origins, and uses that identity for signing and for `appletMessageToParent`.

## Verification

- `yarn typecheck` green; `yarn test:unit` green (11 new policy tests; central case: group cell + `group` zome → REJECT).
- **Adversarial review** by an independent session (bypass / spoofing / allow-list leaks / cache TOCTOU / breakage / WAL completeness): **no confirmed bypass**. Its one real finding — a 3s cache throttle that could wrongly *reject* just-installed cells — is fixed (commit 8bc0b8cc: always refresh once before refusing, coalesced).
- **Runtime e2e** (`tests/e2e/smoke/12.applet-zome-call-roundtrip.spec.ts`): real Moss + real conductor, creates a post in the example applet — signing `create_post` + `get_all_posts` to the applet's own cell — and asserts the post renders. Proven to be a real gate with a negative control (disabling the own-cell arm makes it fail; restored).

## Judgment calls — please sign off

- Enforce in **main** via origin-derived identity (the one place that signs and has admin access to resolve cells).
- Allow `profiles` on **any** installed group cell, not just the applet's own group (benign — user's own profile — and avoids an applet→group map in main).
- WAL cross-group **signing fails closed** (rejected). Believed unused; flag if a real tool hits it.
- Dev-mode `localhost` origins can self-declare identity (pre-existing behavior, dev builds only).
- The group **token handout is unchanged** by design; scoping the signer is what closes the hole.

## Scope / follow-ups

- Runtime e2e covers the **own-cell** arm. The `profiles` arm and a **cross-group** view are unit-tested but not yet exercised at runtime — can add specs if wanted.
- e2e is not in CI (only `unit-and-typecheck` + tryorama gate); #12 is a local/manual gate for now.
- `isPrivateIp` extra ranges + port restriction (assessment §4.3/§4.8) intentionally left to a separate branch (one intent per branch).

Needs a broader manual smoke test with real third-party applets before release.
