### PR TITLE
chore(network): default to bootstrap-relay.moss.social; remove defunct signal server

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,13 +23,12 @@ Options:
   --holochain-wasm-log <string>  WASM_LOG value to pass to the holochain binary
   --lair-rust-log <string>       RUST_LOG value to pass to the lair keystore binary
   -b, --bootstrap-url <url>      URL of the bootstrap server to use (not persisted across restarts).
-  -s, --signaling-url <url>      URL of the signaling server to use (not persisted across restarts).
   -r, --relay-url <url>          URL of the relay server to use (not persisted across restarts).
   --ice-urls <string>            Comma separated string of ICE server URLs to use. Is ignored if an external holochain binary is
                                  being used (not persisted across restarts).
-  --force-production-urls        Explicitly allow using the production URLs of bootstrap and/or singaling server during applet
-                                 development. It is recommended to use hc-local-services to spin up a local bootstrap and signaling
-                                 server instead during development.
+  --force-production-urls        Explicitly allow using the production URL of the bootstrap server during applet development. It is
+                                 recommended to use kitsune2-bootstrap-srv to spin up a local bootstrap server instead during
+                                 development.
   --print-holochain-logs         Print holochain logs directly to the terminal (they will be still written to the logfile as well)
   --disable-os-notifications     Disables all notifications to the Operating System
   --agent-idx <number>           To be provided when running with the --dev-config option. Specifies which agent (as defined in the

--- a/src/main/cli/cli.ts
+++ b/src/main/cli/cli.ts
@@ -12,19 +12,14 @@ const SUPPORTED_APPLET_SOURCE_TYPES = ['localhost', 'filesystem', 'https'];
 // here since there is a check to prevent accidental use of a production bootstrap server in development
 // mode
 export const PRODUCTION_BOOTSTRAP_URLS = [
-  'https://bootstrap.moss.social',
+  'https://bootstrap-relay.moss.social',
   'https://dev-test-bootstrap2.holochain.org',
 ];
-// The first one will be picked by default. But all production signaling servers should be listed
-// here since there is a check to prevent accidental use of a production signaling server in development
-// mode
-export const PRODUCTION_SIGNALING_URLS = [
-  'wss://bootstrap.moss.social',
-  'wss://dev-test-bootstrap2.holochain.org',
-];
-// The first one will be picked by default.
+// The first one will be picked by default. Holochain 0.7 serves the iroh relay
+// from the same kitsune2-bootstrap-srv node as the bootstrap server; the
+// trailing-dot FQDN is the iroh relay URL convention.
 export const PRODUCTION_RELAY_URLS = [
-  'https://iroh-relay.moss.social./',
+  'https://bootstrap-relay.moss.social./',
   'https://use1-1.relay.n0.iroh-canary.iroh.link./',
 ];
 export const DEFAULT_ICE_URLS = ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'];
@@ -46,7 +41,6 @@ export interface CliOpts {
   holochainWasmLog?: string | undefined;
   lairRustLog?: string | undefined;
   bootstrapUrl?: string;
-  signalingUrl?: string;
   relayUrl?: string;
   iceUrls?: string;
   forceProductionUrls?: boolean;
@@ -60,7 +54,6 @@ export interface RunOptions {
   appstoreNetworkSeed: string;
   devInfo: WeAppletDevInfo | undefined;
   bootstrapUrl: string | undefined;
-  signalingUrl: string | undefined;
   relayUrl: string | undefined;
   iceUrls: string[];
   customBinary: string | undefined;
@@ -110,7 +103,7 @@ export function validateArgs(args: CliOpts): RunOptions {
   )
     throw new Error('--sync-time argument must be of type number.');
 
-  // validate bootstarp and signaling urls
+  // validate bootstrap url
   if (args.devConfig) {
     if (
       args.bootstrapUrl &&
@@ -118,15 +111,7 @@ export function validateArgs(args: CliOpts): RunOptions {
       !args.forceProductionUrls
     )
       throw new Error(
-        'The production bootstrap server should not be used in development. Instead, you can spin up a local bootstrap and signaling server with kitsune2-bootstrap-srv. If you explicitly want to use the production server, you need to provide the --force-production-urls flag.',
-      );
-    if (
-      args.signalingUrl &&
-      PRODUCTION_SIGNALING_URLS.includes(args.signalingUrl) &&
-      !args.forceProductionUrls
-    )
-      throw new Error(
-        'The production signaling server should not be used in development. Instead, you can spin up a local bootstrap and signaling server with kitsune2-bootstrap-srv. If you explicitly want to use the production server, you need to provide the --force-production-urls flag.',
+        'The production bootstrap server should not be used in development. Instead, you can spin up a local bootstrap server with kitsune2-bootstrap-srv. If you explicitly want to use the production server, you need to provide the --force-production-urls flag.',
       );
   }
   if (args.holochainPath && typeof args.holochainPath !== 'string') {
@@ -189,7 +174,6 @@ export function validateArgs(args: CliOpts): RunOptions {
     appstoreNetworkSeed,
     devInfo,
     bootstrapUrl: args.bootstrapUrl,
-    signalingUrl: args.signalingUrl,
     relayUrl: args.relayUrl,
     iceUrls: args.iceUrls ? args.iceUrls.split(',') : DEFAULT_ICE_URLS,
     customBinary: args.holochainPath ? args.holochainPath : undefined,

--- a/src/main/cli/devSetup.ts
+++ b/src/main/cli/devSetup.ts
@@ -48,7 +48,7 @@ import { readIcon } from '../utils';
 import { AppletHash } from '@theweave/api';
 const rustUtils = require('@lightningrodlabs/we-rust-utils');
 
-export function readLocalServices(): [string, string, string] {
+export function readLocalServices(): [string, string] {
   if (!fs.existsSync('.kitsune2_bootstrap_srv')) {
     throw new Error(
       'No .kitsune2_bootstrap_srv file found. Make sure agent with agentIdx 1 is running before you start additional agents.',
@@ -56,15 +56,15 @@ export function readLocalServices(): [string, string, string] {
   }
   const localServicesString = fs.readFileSync('.kitsune2_bootstrap_srv', 'utf-8');
   try {
-    const { bootstrapUrl, signalingUrl, relayUrl } = JSON.parse(localServicesString);
-    return [bootstrapUrl, signalingUrl, relayUrl];
+    const { bootstrapUrl, relayUrl } = JSON.parse(localServicesString);
+    return [bootstrapUrl, relayUrl];
   } catch (e) {
     throw new Error('Failed to parse content of .kitsune2_bootstrap_srv');
   }
 }
 
 export async function startLocalServices(): Promise<
-  [string, string, string, childProcess.ChildProcessWithoutNullStreams]
+  [string, string, childProcess.ChildProcessWithoutNullStreams]
 > {
   if (fs.existsSync('.hc_local_services')) {
     fs.rmSync('.hc_local_services');
@@ -82,30 +82,23 @@ export async function startLocalServices(): Promise<
   const localServicesHandle = childProcess.spawn(bootstrapSrvBinary);
   return new Promise((resolve) => {
     let bootstrapUrl;
-    let signalingUrl;
     let relayUrl;
     let bootstrapRunning = false;
-    let signalRunning = false;
     localServicesHandle.stdout.pipe(split()).on('data', async (line: string) => {
       console.log(`[weave-cli] | [kitsune2-bootstrap-srv]: ${line}`);
       if (line.includes('#kitsune2_bootstrap_srv#listening#')) {
         const hostAndPort = line.split('#kitsune2_bootstrap_srv#listening#')[1].split('#')[0];
         bootstrapUrl = `http://${hostAndPort}`;
-        signalingUrl = `ws://${hostAndPort}`;
         // As of kitsune2_bootstrap_srv 0.4.0-dev.7, the relay is served
         // at the /relay route of the bootstrap server itself.
         relayUrl = `http://${hostAndPort}/relay`;
       }
       if (line.includes('#kitsune2_bootstrap_srv#running#')) {
         bootstrapRunning = true;
-        signalRunning = true;
       }
-      fs.writeFileSync(
-        '.kitsune2_bootstrap_srv',
-        JSON.stringify({ bootstrapUrl, signalingUrl, relayUrl }),
-      );
-      if (bootstrapRunning && signalRunning && bootstrapUrl) {
-        resolve([bootstrapUrl, signalingUrl, relayUrl, localServicesHandle]);
+      fs.writeFileSync('.kitsune2_bootstrap_srv', JSON.stringify({ bootstrapUrl, relayUrl }));
+      if (bootstrapRunning && bootstrapUrl) {
+        resolve([bootstrapUrl, relayUrl, localServicesHandle]);
       }
     });
     localServicesHandle.stderr.pipe(split()).on('data', async (line: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -71,7 +71,6 @@ import { nanoid } from 'nanoid';
 import {
   APPLET_DEV_TMP_FOLDER_PREFIX,
   PRODUCTION_BOOTSTRAP_URLS,
-  PRODUCTION_SIGNALING_URLS,
   PRODUCTION_RELAY_URLS,
   validateArgs,
 } from './cli/cli';
@@ -298,10 +297,6 @@ program
   .option(
     '-b, --bootstrap-url <url>',
     'URL of the bootstrap server to use (not persisted across restarts).',
-  )
-  .option(
-    '-s, --signaling-url <url>',
-    'URL of the signaling server to use (not persisted across restarts).',
   )
   .option(
     '-r, --relay-url <url>',
@@ -691,7 +686,7 @@ if (!RUNNING_WITH_COMMAND) {
    * Determine the URLs for the network services
    * In production return run options or hardcoded production urls
    * In dev return run options or local services urls
-   * @returns [bootstrapUrl[], signalingUrl[], relayUrl[]]
+   * @returns [bootstrapUrl[], relayUrl[]]
    */
   const getNetworkUrls = (): NetworkInfo => {
     // Production
@@ -700,16 +695,12 @@ if (!RUNNING_WITH_COMMAND) {
         bootstrap_urls: RUN_OPTIONS.bootstrapUrl
           ? [RUN_OPTIONS.bootstrapUrl]
           : PRODUCTION_BOOTSTRAP_URLS,
-        signal_urls: RUN_OPTIONS.signalingUrl
-          ? [RUN_OPTIONS.signalingUrl]
-          : PRODUCTION_SIGNALING_URLS,
         relay_urls: RUN_OPTIONS.relayUrl ? [RUN_OPTIONS.relayUrl] : PRODUCTION_RELAY_URLS,
       };
     }
-    const [bootstrapUrl, signalingUrl, relayUrl] = readLocalServices();
+    const [bootstrapUrl, relayUrl] = readLocalServices();
     return {
       bootstrap_urls: [RUN_OPTIONS.bootstrapUrl ?? bootstrapUrl],
-      signal_urls: [RUN_OPTIONS.signalingUrl ?? signalingUrl],
       relay_urls: [RUN_OPTIONS.relayUrl ?? relayUrl],
     };
   };
@@ -1116,17 +1107,14 @@ if (!RUNNING_WITH_COMMAND) {
 
     SYSTRAY.setContextMenu(contextMenu);
 
-    if (!RUN_OPTIONS.bootstrapUrl || !RUN_OPTIONS.signalingUrl || !RUN_OPTIONS.relayUrl) {
+    if (!RUN_OPTIONS.bootstrapUrl || !RUN_OPTIONS.relayUrl) {
       // in dev mode
       if (RUN_OPTIONS.devInfo) {
-        const [bootstrapUrl, signalingUrl, relayUrl, localServicesHandle] =
+        const [bootstrapUrl, relayUrl, localServicesHandle] =
           RUN_OPTIONS.devInfo.agentIdx === 1 ? await startLocalServices() : readLocalServices();
         RUN_OPTIONS.bootstrapUrl = RUN_OPTIONS.bootstrapUrl
           ? RUN_OPTIONS.bootstrapUrl
           : bootstrapUrl;
-        RUN_OPTIONS.signalingUrl = RUN_OPTIONS.signalingUrl
-          ? RUN_OPTIONS.signalingUrl
-          : signalingUrl;
         RUN_OPTIONS.relayUrl = RUN_OPTIONS.relayUrl ? RUN_OPTIONS.relayUrl : relayUrl;
         LOCAL_SERVICES_HANDLE = localServicesHandle;
       } else {
@@ -1134,9 +1122,6 @@ if (!RUNNING_WITH_COMMAND) {
         RUN_OPTIONS.bootstrapUrl = RUN_OPTIONS.bootstrapUrl
           ? RUN_OPTIONS.bootstrapUrl
           : (networkOverrides.bootstrapUrl ?? PRODUCTION_BOOTSTRAP_URLS[0]);
-        RUN_OPTIONS.signalingUrl = RUN_OPTIONS.signalingUrl
-          ? RUN_OPTIONS.signalingUrl
-          : PRODUCTION_SIGNALING_URLS[0];
         RUN_OPTIONS.relayUrl = RUN_OPTIONS.relayUrl
           ? RUN_OPTIONS.relayUrl
           : (networkOverrides.relayUrl ?? PRODUCTION_RELAY_URLS[0]);
@@ -1738,7 +1723,7 @@ if (!RUNNING_WITH_COMMAND) {
         }, 5000);
       }
       /** Grab Network Urls */
-      let network_info: NetworkInfo = { bootstrap_urls: [], signal_urls: [], relay_urls: [] };
+      let network_info: NetworkInfo = { bootstrap_urls: [], relay_urls: [] };
       try {
         network_info = getNetworkUrls();
       } catch (e) {

--- a/src/main/launch.ts
+++ b/src/main/launch.ts
@@ -26,9 +26,9 @@ export async function launch(
 ): Promise<[childProcess.ChildProcessWithoutNullStreams, HolochainManager, WeRustHandler]> {
   console.log('LAIR BINARY PATH: ', LAIR_BINARY);
   //console.log('runOptions: ', JSON.stringify(runOptions, null, 2));
-  if (!runOptions.relayUrl && (!runOptions.bootstrapUrl || !runOptions.signalingUrl)) {
+  if (!runOptions.relayUrl && !runOptions.bootstrapUrl) {
     throw new Error(
-      `Failed to launch HolochainManager: bootstrapUrl, relayUrl or signalingUrl is not set in runOptions.`,
+      `Failed to launch HolochainManager: neither bootstrapUrl nor relayUrl is set in runOptions.`,
     );
   }
   // Initialize lair if necessary

--- a/src/main/sharedTypes.ts
+++ b/src/main/sharedTypes.ts
@@ -27,7 +27,6 @@ export type DeveloperCollective = {
 // CHANGE ALSO IN src/renderer/src/electron-api.ts
 export interface NetworkInfo {
   bootstrap_urls: string[];
-  signal_urls: string[];
   relay_urls: string[];
 }
 // CHANGE ALSO IN src/renderer/src/electron-api.ts

--- a/src/renderer/src/app/debugging-panel/debugging-panel.ts
+++ b/src/renderer/src/app/debugging-panel/debugging-panel.ts
@@ -1778,28 +1778,6 @@ export class DebuggingPanel extends LitElement {
               >
               <div id="bootstrap-result" style="display:none; margin-left:5px;"></div>
             </dd>
-            <dt>Signal</dt>
-            <dd>
-              ${this._mossStore.conductorInfo.network_info.signal_urls.length
-                ? this._mossStore.conductorInfo.network_info.signal_urls[0]
-                : 'None'}
-              <sl-button
-                size="small"
-                @click=${async (_e) => {
-                  const res = await pingServer(
-                    this._mossStore.conductorInfo.network_info.signal_urls[0],
-                  );
-                  const elem = this.shadowRoot?.getElementById('signal-result') as HTMLElement;
-                  if (!elem) return;
-                  elem.style.display = 'inline';
-                  elem.style.color = res.online ? 'green' : 'red';
-                  elem.innerHTML = res.online ? `online - ${res.latencyMs} ms` : 'offline';
-                  this.requestUpdate();
-                }}
-                >Ping</sl-button
-              >
-              <div id="signal-result" style="display:none; margin-left:5px;"></div>
-            </dd>
             <dt>Relay</dt>
             <dd>
               ${this._mossStore.conductorInfo.network_info.relay_urls.length

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -275,7 +275,6 @@ export interface ProgressInfo {
 
 export interface NetworkInfo {
   bootstrap_urls: string[];
-  signal_urls: string[];
   relay_urls: string[];
 }
 

--- a/tests/e2e/fixtures/bootstrap.ts
+++ b/tests/e2e/fixtures/bootstrap.ts
@@ -20,7 +20,6 @@ import readline from 'node:readline';
  */
 export type BootstrapUrls = {
   bootstrapUrl: string;
-  signalingUrl: string;
   relayUrl: string;
 };
 
@@ -71,7 +70,6 @@ export async function startBootstrap(): Promise<RunningBootstrap> {
 
   return new Promise<RunningBootstrap>((resolve, reject) => {
     let bootstrapUrl: string | undefined;
-    let signalingUrl: string | undefined;
     let relayUrl: string | undefined;
     let running = false;
 
@@ -85,9 +83,9 @@ export async function startBootstrap(): Promise<RunningBootstrap> {
     }, 15_000);
 
     const finishIfReady = () => {
-      if (running && bootstrapUrl && signalingUrl && relayUrl) {
+      if (running && bootstrapUrl && relayUrl) {
         clearTimeout(timeout);
-        resolve({ bootstrapUrl, signalingUrl, relayUrl, proc });
+        resolve({ bootstrapUrl, relayUrl, proc });
       }
     };
 
@@ -95,7 +93,6 @@ export async function startBootstrap(): Promise<RunningBootstrap> {
       if (line.includes('#kitsune2_bootstrap_srv#listening#')) {
         const hostAndPort = line.split('#kitsune2_bootstrap_srv#listening#')[1].split('#')[0];
         bootstrapUrl = `http://${hostAndPort}`;
-        signalingUrl = `ws://${hostAndPort}`;
         relayUrl = `http://${hostAndPort}/relay`;
       }
       if (line.includes('#kitsune2_bootstrap_srv#running#')) {

--- a/tests/e2e/fixtures/moss.ts
+++ b/tests/e2e/fixtures/moss.ts
@@ -37,9 +37,9 @@ export type LaunchOptions = {
   mossProfile?: string;
   /**
    * Local kitsune2 bootstrap URLs to plumb to Moss via --bootstrap-url /
-   * --signaling-url / --relay-url. When provided, both agents in a multi-agent
-   * test share a single in-process bootstrap, so cross-agent peer discovery
-   * converges in seconds rather than minutes.
+   * --relay-url. When provided, both agents in a multi-agent test share a
+   * single in-process bootstrap, so cross-agent peer discovery converges in
+   * seconds rather than minutes.
    */
   bootstrap?: BootstrapUrls;
   /**
@@ -122,8 +122,6 @@ export async function launchMoss(opts: LaunchOptions): Promise<LaunchedMoss> {
       ? [
           '--bootstrap-url',
           opts.bootstrap.bootstrapUrl,
-          '--signaling-url',
-          opts.bootstrap.signalingUrl,
           '--relay-url',
           opts.bootstrap.relayUrl,
         ]
@@ -291,7 +289,6 @@ export const test = base.extend<MossTestFixtures, MossWorkerFixtures>({
         running = await startBootstrap();
         await use({
           bootstrapUrl: running.bootstrapUrl,
-          signalingUrl: running.signalingUrl,
           relayUrl: running.relayUrl,
         });
       } finally {


### PR DESCRIPTION
## What

The unified Holochain 0.7 bootstrap + iroh relay node **bootstrap-relay.moss.social** is live, so:

- **Defaults updated** — `PRODUCTION_BOOTSTRAP_URLS` and `PRODUCTION_RELAY_URLS` now lead with `https://bootstrap-relay.moss.social` (relay uses the trailing-dot iroh FQDN form `.../`). One `kitsune2-bootstrap-srv` node serves both, replacing the separate `bootstrap.moss.social` + `iroh-relay.moss.social`.
- **Signal server removed** — Holochain 0.7 has no signal server (0.6's sbd is gone; the conductor config path already deletes `signal_url`). Cleaned up the now-defunct references:
  - the **Signal** row in the debugging panel
  - `signal_urls` from `NetworkInfo` (main + renderer) and `getNetworkUrls`
  - `PRODUCTION_SIGNALING_URLS`, the `signalingUrl` RunOptions/arg, the `--signaling-url` CLI option + its dev-mode production guard, and the launch/devSetup plumbing
  - `--signaling-url` from the e2e launch fixtures and the CLI README

## Verification

- `yarn typecheck` + `yarn test:unit` green.
- e2e `#12` passes — it spins up the local bootstrap fixture and launches Moss with the new args (no `--signaling-url`) and the signing round-trip, exercising this change end to end.

## Scope

`wdocker/` carries its own copy of these `PRODUCTION_*` constants + signal plumbing; left for a follow-up as discussed.