### PR TITLE
Phase 1: wire-contract drift guards + F4 crash detection (+ small follow-ups)

### DIFF
--- a/src/main/appletZomeCallAuthorizer.test.ts
+++ b/src/main/appletZomeCallAuthorizer.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AppInfo,
+  CallZomeRequest,
+  CellId,
+  CellInfo,
+  CellType,
+  encodeHashToBase64,
+} from '@holochain/client';
+import { appIdFromAppletId } from '@theweave/utils';
+import { AppletZomeCallAuthorizer } from './appletZomeCallAuthorizer';
+
+const AGENT = new Uint8Array([0, 1, 2]);
+const cellId = (dna: number[]): CellId => [new Uint8Array(dna), AGENT];
+
+function provisioned(id: CellId): CellInfo {
+  return { type: CellType.Provisioned, value: { cell_id: id, name: 'c' } } as unknown as CellInfo;
+}
+
+// Two applets and one group app. The group app has group/foyer/assets role cells;
+// only the group-role cell may be signed for (profiles zome only).
+const APPLET_A = encodeHashToBase64(new Uint8Array([10, 10, 10]));
+const APPLET_B = encodeHashToBase64(new Uint8Array([20, 20, 20]));
+const A_CELL = cellId([100]);
+const B_CELL = cellId([200]);
+const GROUP_CELL = cellId([1]);
+const FOYER_CELL = cellId([2]);
+const ASSETS_CELL = cellId([3]);
+const FOREIGN_CELL = cellId([255]);
+
+function apps(): AppInfo[] {
+  return [
+    { installed_app_id: appIdFromAppletId(APPLET_A), cell_info: { forum: [provisioned(A_CELL)] } },
+    { installed_app_id: appIdFromAppletId(APPLET_B), cell_info: { forum: [provisioned(B_CELL)] } },
+    {
+      installed_app_id: 'group#seed#prog',
+      cell_info: {
+        group: [provisioned(GROUP_CELL)],
+        foyer: [provisioned(FOYER_CELL)],
+        assets: [provisioned(ASSETS_CELL)],
+      },
+    },
+  ] as unknown as AppInfo[];
+}
+
+function req(id: CellId, zome_name: string): CallZomeRequest {
+  return { cell_id: id, zome_name } as unknown as CallZomeRequest;
+}
+
+function makeAuthorizer() {
+  let listAppsCalls = 0;
+  const authorizer = new AppletZomeCallAuthorizer(async () => {
+    listAppsCalls += 1;
+    return apps();
+  });
+  return { authorizer, calls: () => listAppsCalls };
+}
+
+describe('AppletZomeCallAuthorizer', () => {
+  it('signs an applet call to its own cell (any zome)', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect(await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).toEqual({
+      sign: true,
+      reason: 'own-cell',
+    });
+  });
+
+  it('signs a group-cell profiles call', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect(await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'profiles'))).toEqual({
+      sign: true,
+      reason: 'group-profiles',
+    });
+  });
+
+  it('refuses a group-cell non-profiles zome (the core vulnerability)', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect(await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'group'))).toEqual({
+      sign: false,
+      reason: 'group-zome-not-allowed',
+    });
+  });
+
+  it('refuses the group app foyer/assets cells (not the group role)', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect((await authorizer.authorize([APPLET_A], req(FOYER_CELL, 'foyer'))).sign).toBe(false);
+    expect((await authorizer.authorize([APPLET_A], req(ASSETS_CELL, 'assets'))).sign).toBe(false);
+  });
+
+  it('refuses another applet’s own cell', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect(await authorizer.authorize([APPLET_A], req(B_CELL, 'posts'))).toEqual({
+      sign: false,
+      reason: 'unknown-cell',
+    });
+  });
+
+  it('a cross-group caller may sign for any of its tool’s applets', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect((await authorizer.authorize([APPLET_A, APPLET_B], req(B_CELL, 'posts'))).sign).toBe(true);
+  });
+
+  it('refuses a missing cell_id', async () => {
+    const { authorizer } = makeAuthorizer();
+    expect(await authorizer.authorize([APPLET_A], { zome_name: 'x' } as CallZomeRequest)).toEqual({
+      sign: false,
+      reason: 'unknown-cell',
+    });
+  });
+
+  it('refreshes once on an unknown cell, but not on a known-cell refusal', async () => {
+    const { authorizer, calls } = makeAuthorizer();
+    // First call builds the cache (1) then, being unknown, refreshes once (2).
+    await authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
+    expect(calls()).toBe(2);
+    // A group-zome refusal is not re-checked — a rebuild cannot flip it.
+    await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'group'));
+    expect(calls()).toBe(2);
+  });
+
+  it('caches: an allowed call after the cache is warm does not re-list', async () => {
+    const { authorizer, calls } = makeAuthorizer();
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(calls()).toBe(1);
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(calls()).toBe(1);
+  });
+
+  it('invalidate() forces a re-list on the next authorize', async () => {
+    const { authorizer, calls } = makeAuthorizer();
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(calls()).toBe(1);
+    authorizer.invalidate();
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(calls()).toBe(2);
+  });
+});

--- a/src/main/appletZomeCallAuthorizer.test.ts
+++ b/src/main/appletZomeCallAuthorizer.test.ts
@@ -17,48 +17,61 @@ function provisioned(id: CellId): CellInfo {
   return { type: CellType.Provisioned, value: { cell_id: id, name: 'c' } } as unknown as CellInfo;
 }
 
-// Two applets and one group app. The group app has group/foyer/assets role cells;
-// only the group-role cell may be signed for (profiles zome only).
 const APPLET_A = encodeHashToBase64(new Uint8Array([10, 10, 10]));
 const APPLET_B = encodeHashToBase64(new Uint8Array([20, 20, 20]));
+const APPLET_C = encodeHashToBase64(new Uint8Array([30, 30, 30]));
 const A_CELL = cellId([100]);
 const B_CELL = cellId([200]);
+const C_CELL = cellId([210]);
 const GROUP_CELL = cellId([1]);
 const FOYER_CELL = cellId([2]);
 const ASSETS_CELL = cellId([3]);
 const FOREIGN_CELL = cellId([255]);
 
-function apps(): AppInfo[] {
-  return [
-    { installed_app_id: appIdFromAppletId(APPLET_A), cell_info: { forum: [provisioned(A_CELL)] } },
-    { installed_app_id: appIdFromAppletId(APPLET_B), cell_info: { forum: [provisioned(B_CELL)] } },
-    {
-      installed_app_id: 'group#seed#prog',
-      cell_info: {
-        group: [provisioned(GROUP_CELL)],
-        foyer: [provisioned(FOYER_CELL)],
-        assets: [provisioned(ASSETS_CELL)],
-      },
+const appletApp = (id: string, cell: CellId): AppInfo =>
+  ({ installed_app_id: appIdFromAppletId(id), cell_info: { forum: [provisioned(cell)] } }) as unknown as AppInfo;
+
+const groupApp = (): AppInfo =>
+  ({
+    installed_app_id: 'group#seed#prog',
+    cell_info: {
+      group: [provisioned(GROUP_CELL)],
+      foyer: [provisioned(FOYER_CELL)],
+      assets: [provisioned(ASSETS_CELL)],
     },
-  ] as unknown as AppInfo[];
-}
+  }) as unknown as AppInfo;
 
 function req(id: CellId, zome_name: string): CallZomeRequest {
   return { cell_id: id, zome_name } as unknown as CallZomeRequest;
 }
 
-function makeAuthorizer() {
-  let listAppsCalls = 0;
-  const authorizer = new AppletZomeCallAuthorizer(async () => {
-    listAppsCalls += 1;
-    return apps();
-  });
-  return { authorizer, calls: () => listAppsCalls };
+/** Harness with a controllable clock and mutable installed-app list. */
+function harness(initial: AppInfo[] = [appletApp(APPLET_A, A_CELL), appletApp(APPLET_B, B_CELL), groupApp()]) {
+  let now = 0;
+  let apps = initial;
+  let calls = 0;
+  const authorizer = new AppletZomeCallAuthorizer(
+    async () => {
+      calls += 1;
+      return apps;
+    },
+    () => now,
+  );
+  return {
+    authorizer,
+    calls: () => calls,
+    advance: (ms: number) => {
+      now += ms;
+    },
+    setApps: (a: AppInfo[]) => {
+      apps = a;
+    },
+  };
 }
 
 describe('AppletZomeCallAuthorizer', () => {
   it('signs an applet call to its own cell (any zome)', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect(await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).toEqual({
       sign: true,
       reason: 'own-cell',
@@ -66,7 +79,7 @@ describe('AppletZomeCallAuthorizer', () => {
   });
 
   it('signs a group-cell profiles call', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect(await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'profiles'))).toEqual({
       sign: true,
       reason: 'group-profiles',
@@ -74,7 +87,7 @@ describe('AppletZomeCallAuthorizer', () => {
   });
 
   it('refuses a group-cell non-profiles zome (the core vulnerability)', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect(await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'group'))).toEqual({
       sign: false,
       reason: 'group-zome-not-allowed',
@@ -82,13 +95,13 @@ describe('AppletZomeCallAuthorizer', () => {
   });
 
   it('refuses the group app foyer/assets cells (not the group role)', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect((await authorizer.authorize([APPLET_A], req(FOYER_CELL, 'foyer'))).sign).toBe(false);
     expect((await authorizer.authorize([APPLET_A], req(ASSETS_CELL, 'assets'))).sign).toBe(false);
   });
 
   it('refuses another applet’s own cell', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect(await authorizer.authorize([APPLET_A], req(B_CELL, 'posts'))).toEqual({
       sign: false,
       reason: 'unknown-cell',
@@ -96,42 +109,104 @@ describe('AppletZomeCallAuthorizer', () => {
   });
 
   it('a cross-group caller may sign for any of its tool’s applets', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect((await authorizer.authorize([APPLET_A, APPLET_B], req(B_CELL, 'posts'))).sign).toBe(true);
   });
 
   it('refuses a missing cell_id', async () => {
-    const { authorizer } = makeAuthorizer();
+    const { authorizer } = harness();
     expect(await authorizer.authorize([APPLET_A], { zome_name: 'x' } as CallZomeRequest)).toEqual({
       sign: false,
       reason: 'unknown-cell',
     });
   });
 
-  it('refreshes once on an unknown cell, but not on a known-cell refusal', async () => {
-    const { authorizer, calls } = makeAuthorizer();
-    // First call builds the cache (1) then, being unknown, refreshes once (2).
+  it('does not re-list on a fresh build even when the cell is unknown', async () => {
+    const { authorizer, calls } = harness();
+    // The build itself is one listApps; re-listing immediately would not find a
+    // cell that was absent moments ago, so it is throttled.
     await authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
-    expect(calls()).toBe(2);
-    // A group-zome refusal is not re-checked — a rebuild cannot flip it.
-    await authorizer.authorize([APPLET_A], req(GROUP_CELL, 'group'));
-    expect(calls()).toBe(2);
+    expect(calls()).toBe(1);
   });
 
   it('caches: an allowed call after the cache is warm does not re-list', async () => {
-    const { authorizer, calls } = makeAuthorizer();
+    const { authorizer, calls } = harness();
     await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
     expect(calls()).toBe(1);
     await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
     expect(calls()).toBe(1);
   });
 
+  it('picks up a just-installed applet after the throttle interval (no false refusal)', async () => {
+    const h = harness();
+    // Warm the cache before APPLET_C exists.
+    await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(h.calls()).toBe(1);
+    // APPLET_C is installed, and its iframe calls after mounting (> throttle).
+    h.setApps([appletApp(APPLET_A, A_CELL), appletApp(APPLET_C, C_CELL), groupApp()]);
+    h.advance(1_500);
+    expect((await h.authorizer.authorize([APPLET_C], req(C_CELL, 'posts'))).sign).toBe(true);
+    expect(h.calls()).toBe(2); // one refresh, which found it
+  });
+
+  it('throttles rebuilds under a flood of unknown-cell calls', async () => {
+    const h = harness();
+    await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts')); // build (1)
+    h.advance(1_500);
+    await h.authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x')); // refresh (2)
+    expect(h.calls()).toBe(2);
+    // Further unknown-cell calls within the throttle window do not re-list.
+    await h.authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
+    await h.authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
+    expect(h.calls()).toBe(2);
+  });
+
   it('invalidate() forces a re-list on the next authorize', async () => {
-    const { authorizer, calls } = makeAuthorizer();
-    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
-    expect(calls()).toBe(1);
+    const h = harness();
+    await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(h.calls()).toBe(1);
+    h.authorizer.invalidate();
+    await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    expect(h.calls()).toBe(2);
+  });
+
+  it('self-heals a missed uninstall once the cache ages past the max (leaveGroup bypass)', async () => {
+    const h = harness();
+    // A is granted while installed.
+    expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
+    // A is uninstalled via a path that does NOT call invalidate() (leaveGroup).
+    h.setApps([appletApp(APPLET_B, B_CELL), groupApp()]);
+    // Before the max age, the stale grant may persist (no live iframe uses it)...
+    h.advance(30_000);
+    expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
+    // ...but past the max age the cache is rebuilt and the grant is gone.
+    h.advance(61_000);
+    expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(false);
+  });
+
+  it('an invalidate during an in-flight rebuild discards that stale snapshot (generation)', async () => {
+    let now = 0;
+    let apps = [appletApp(APPLET_A, A_CELL)];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let calls = 0;
+    const authorizer = new AppletZomeCallAuthorizer(
+      async () => {
+        calls += 1;
+        await gate; // hold the first listApps open
+        return apps;
+      },
+      () => now,
+    );
+    // Start a rebuild that will resolve to the pre-uninstall snapshot.
+    const first = authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    // App is uninstalled and invalidate() is called while listApps is in flight.
+    apps = [];
     authorizer.invalidate();
-    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
-    expect(calls()).toBe(2);
+    release();
+    await first;
+    // The stale snapshot must not have been committed: A is no longer granted.
+    expect((await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(false);
+    expect(calls).toBeGreaterThanOrEqual(2); // the discarded build + a fresh one
   });
 });

--- a/src/main/appletZomeCallAuthorizer.test.ts
+++ b/src/main/appletZomeCallAuthorizer.test.ts
@@ -214,6 +214,35 @@ describe('AppletZomeCallAuthorizer', () => {
     await flush();
   });
 
+  it('rate-limits doomed background refreshes during an outage (one per interval)', async () => {
+    let now = 0;
+    let calls = 0;
+    let fail = false;
+    const authorizer = new AppletZomeCallAuthorizer(
+      async () => {
+        calls += 1;
+        if (fail) throw new Error('admin socket down');
+        return [appletApp(APPLET_A, A_CELL), groupApp()];
+      },
+      () => now,
+    );
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts')); // build (1)
+    expect(calls).toBe(1);
+    now += 61_000; // stale
+    fail = true; // outage
+    // Three signs during the outage fire only one background refresh attempt.
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    await flush();
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    await flush();
+    expect(calls).toBe(2);
+    now += 2_000; // past the interval → one more attempt allowed
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    await flush();
+    expect(calls).toBe(3);
+  });
+
   it('an invalidate during an in-flight rebuild discards that stale snapshot (generation)', async () => {
     const { authorizer, releaseListApps, setApps } = gatedHarness([appletApp(APPLET_A, A_CELL)]);
     const first = authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));

--- a/src/main/appletZomeCallAuthorizer.test.ts
+++ b/src/main/appletZomeCallAuthorizer.test.ts
@@ -29,7 +29,10 @@ const ASSETS_CELL = cellId([3]);
 const FOREIGN_CELL = cellId([255]);
 
 const appletApp = (id: string, cell: CellId): AppInfo =>
-  ({ installed_app_id: appIdFromAppletId(id), cell_info: { forum: [provisioned(cell)] } }) as unknown as AppInfo;
+  ({
+    installed_app_id: appIdFromAppletId(id),
+    cell_info: { forum: [provisioned(cell)] },
+  }) as unknown as AppInfo;
 
 const groupApp = (): AppInfo =>
   ({
@@ -46,7 +49,9 @@ function req(id: CellId, zome_name: string): CallZomeRequest {
 }
 
 /** Harness with a controllable clock and mutable installed-app list. */
-function harness(initial: AppInfo[] = [appletApp(APPLET_A, A_CELL), appletApp(APPLET_B, B_CELL), groupApp()]) {
+function harness(
+  initial: AppInfo[] = [appletApp(APPLET_A, A_CELL), appletApp(APPLET_B, B_CELL), groupApp()],
+) {
   let now = 0;
   let apps = initial;
   let calls = 0;
@@ -110,7 +115,9 @@ describe('AppletZomeCallAuthorizer', () => {
 
   it('a cross-group caller may sign for any of its tool’s applets', async () => {
     const { authorizer } = harness();
-    expect((await authorizer.authorize([APPLET_A, APPLET_B], req(B_CELL, 'posts'))).sign).toBe(true);
+    expect((await authorizer.authorize([APPLET_A, APPLET_B], req(B_CELL, 'posts'))).sign).toBe(
+      true,
+    );
   });
 
   it('refuses a missing cell_id', async () => {
@@ -170,43 +177,86 @@ describe('AppletZomeCallAuthorizer', () => {
     expect(h.calls()).toBe(2);
   });
 
-  it('self-heals a missed uninstall once the cache ages past the max (leaveGroup bypass)', async () => {
+  it('self-heals a missed uninstall via a background refresh once past the max age', async () => {
     const h = harness();
-    // A is granted while installed.
+    // A is granted while installed (cache built at t=0).
     expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
     // A is uninstalled via a path that does NOT call invalidate() (leaveGroup).
     h.setApps([appletApp(APPLET_B, B_CELL), groupApp()]);
-    // Before the max age, the stale grant may persist (no live iframe uses it)...
+    // Within the max age the stale grant persists (no live iframe uses it).
     h.advance(30_000);
     expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
-    // ...but past the max age the cache is rebuilt and the grant is gone.
-    h.advance(61_000);
+    // Past the max age, the first call still serves the stale set (does not block)
+    // but kicks a background refresh.
+    h.advance(31_000);
+    expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
+    // Once the refresh settles, the grant is gone.
+    await flush();
     expect((await h.authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(false);
   });
 
-  it('an invalidate during an in-flight rebuild discards that stale snapshot (generation)', async () => {
+  it('keeps signing when a stale-age background refresh rejects', async () => {
     let now = 0;
-    let apps = [appletApp(APPLET_A, A_CELL)];
-    let release!: () => void;
-    const gate = new Promise<void>((r) => (release = r));
-    let calls = 0;
+    let fail = false;
     const authorizer = new AppletZomeCallAuthorizer(
       async () => {
-        calls += 1;
-        await gate; // hold the first listApps open
-        return apps;
+        if (fail) throw new Error('admin socket reconnecting');
+        return [appletApp(APPLET_A, A_CELL), groupApp()];
       },
       () => now,
     );
-    // Start a rebuild that will resolve to the pre-uninstall snapshot.
+    expect((await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
+    now += 61_000; // stale; the background refresh will now reject
+    fail = true;
+    // Signing keeps working against the warm cache; the rejected refresh does not
+    // propagate (and must not surface as an unhandled rejection).
+    expect((await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
+    await flush();
+  });
+
+  it('an invalidate during an in-flight rebuild discards that stale snapshot (generation)', async () => {
+    const { authorizer, releaseListApps, setApps } = gatedHarness([appletApp(APPLET_A, A_CELL)]);
     const first = authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
-    // App is uninstalled and invalidate() is called while listApps is in flight.
-    apps = [];
+    setApps([]); // uninstalled while listApps is in flight
     authorizer.invalidate();
-    release();
+    releaseListApps();
     await first;
     // The stale snapshot must not have been committed: A is no longer granted.
     expect((await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(false);
-    expect(calls).toBeGreaterThanOrEqual(2); // the discarded build + a fresh one
+  });
+
+  it('a legit call after an in-flight invalidate rebuilds fresh (no strand)', async () => {
+    // The discarded rebuild must not leave the authorizer refusing a cell that is
+    // still installed: the next call re-lists and grants it.
+    const { authorizer, releaseListApps } = gatedHarness([appletApp(APPLET_A, A_CELL), groupApp()]);
+    const first = authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));
+    authorizer.invalidate();
+    releaseListApps();
+    await first;
+    expect((await authorizer.authorize([APPLET_A], req(A_CELL, 'posts'))).sign).toBe(true);
   });
 });
+
+/** Resolve after pending microtasks + one macrotask so background rebuilds settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+/** Harness whose listApps blocks until releaseListApps() is called, for in-flight races. */
+function gatedHarness(initial: AppInfo[]) {
+  let apps = initial;
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  const authorizer = new AppletZomeCallAuthorizer(
+    async () => {
+      await gate;
+      return apps;
+    },
+    () => 0,
+  );
+  return {
+    authorizer,
+    releaseListApps: () => release(),
+    setApps: (a: AppInfo[]) => {
+      apps = a;
+    },
+  };
+}

--- a/src/main/appletZomeCallAuthorizer.test.ts
+++ b/src/main/appletZomeCallAuthorizer.test.ts
@@ -243,6 +243,35 @@ describe('AppletZomeCallAuthorizer', () => {
     expect(calls).toBe(3);
   });
 
+  it('an unknown-cell call during an outage refuses without throwing or flooding listApps', async () => {
+    let now = 0;
+    let calls = 0;
+    let fail = false;
+    const authorizer = new AppletZomeCallAuthorizer(
+      async () => {
+        calls += 1;
+        if (fail) throw new Error('admin socket down');
+        return [appletApp(APPLET_A, A_CELL), groupApp()];
+      },
+      () => now,
+    );
+    await authorizer.authorize([APPLET_A], req(A_CELL, 'posts')); // build (1)
+    now += 61_000;
+    fail = true;
+    // Unknown cell during the outage: refuses cleanly (no raw socket error) ...
+    expect(await authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'))).toEqual({
+      sign: false,
+      reason: 'unknown-cell',
+    });
+    await flush();
+    const attemptsSoFar = calls;
+    // ... and further unknown-cell calls within the interval fire no new round-trips.
+    await authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
+    await authorizer.authorize([APPLET_A], req(FOREIGN_CELL, 'x'));
+    await flush();
+    expect(calls).toBe(attemptsSoFar);
+  });
+
   it('an invalidate during an in-flight rebuild discards that stale snapshot (generation)', async () => {
     const { authorizer, releaseListApps, setApps } = gatedHarness([appletApp(APPLET_A, A_CELL)]);
     const first = authorizer.authorize([APPLET_A], req(A_CELL, 'posts'));

--- a/src/main/appletZomeCallAuthorizer.ts
+++ b/src/main/appletZomeCallAuthorizer.ts
@@ -4,22 +4,26 @@ import type { AppletId } from '@theweave/api';
 import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCallSigningPolicy';
 
 /**
- * How long a resolved cell set may be trusted before it is rebuilt from live app
- * info. This is the self-heal window for an uninstall that never called
- * invalidate() — notably the renderer's leaveGroup, which uninstalls apps
- * through its own admin websocket and so bypasses the main-process invalidate
- * sites. Within this window a torn-down applet's cells can still be granted, but
- * there is no iframe left to request signing for them.
+ * How long a resolved cell set may be served before it is refreshed. Past this
+ * age the cache is refreshed in the background while the current (stale) set is
+ * still used to decide, so signing never blocks on — or fails with — a listApps
+ * round-trip. It is the self-heal window for an uninstall that never called
+ * invalidate(): notably the renderer's leaveGroup, which uninstalls apps through
+ * its own admin websocket and so bypasses the main-process invalidate sites. A
+ * torn-down applet's cells can still be granted for up to this window, but there
+ * is no iframe left to request signing for them.
  */
 const CACHE_MAX_AGE_MS = 60_000;
 
 /**
  * Minimum time between rebuilds triggered by an unknown-cell refusal. A rebuild
- * picks up an applet or group installed since the last build (so a legitimate
- * just-installed cell is not falsely refused), but only once per interval, so a
- * flood of calls to a genuinely-unknown cell cannot drive an unthrottled
- * listApps per call. The interval is well below the time it takes a
- * newly-installed applet's iframe to mount and make its first call.
+ * picks up an applet or group installed since the last build, but only once per
+ * interval, so a flood of calls to a genuinely-unknown cell cannot drive an
+ * unthrottled listApps per call. Legitimate new cells do not depend on this
+ * timing: the install IPC handlers call invalidate(), which drops the cache so
+ * the next call rebuilds regardless of the interval. The residual case is a cell
+ * that appears with no main-process signal (an applet cloning its own DNA over
+ * the app websocket) and is called within the interval of the last build.
  */
 const MIN_UNKNOWN_REBUILD_INTERVAL_MS = 1_000;
 
@@ -29,17 +33,18 @@ const MIN_UNKNOWN_REBUILD_INTERVAL_MS = 1_000;
  * decideZomeCallSignable policy).
  *
  * Resolving the allowed cells is a listApps round-trip and signing is on the hot
- * path, so the result is cached. Freshness is maintained three ways: invalidate()
- * drops it immediately (called on the IPC uninstall paths); a request that the
- * cached view refuses for an *unknown* cell rebuilds once (throttled) so a
- * just-installed cell is picked up; and a cache older than CACHE_MAX_AGE_MS is
- * rebuilt before use so a missed invalidate self-heals. A generation counter
- * ensures an invalidate() during an in-flight rebuild discards that rebuild's
- * (now stale) snapshot instead of silently restoring it.
+ * path, so the result is cached. Freshness is maintained four ways: invalidate()
+ * drops it immediately (called on the app install/uninstall IPC paths); a request
+ * refused for an *unknown* cell rebuilds once (throttled) so a just-installed
+ * cell is picked up; a cache older than CACHE_MAX_AGE_MS is refreshed in the
+ * background so a missed invalidate self-heals without blocking signing; and a
+ * generation counter makes an invalidate() during an in-flight rebuild discard
+ * that rebuild's (now stale) snapshot instead of committing it.
  */
 export class AppletZomeCallAuthorizer {
-  private cache: { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string> } | undefined;
-  private builtAt = 0;
+  private cache:
+    | { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string>; builtAt: number }
+    | undefined;
   private generation = 0;
   private rebuildInFlight: Promise<void> | undefined;
 
@@ -68,12 +73,22 @@ export class AppletZomeCallAuthorizer {
         groupCellIdsB64: this.cache?.groupCells ?? new Set(),
       });
 
-    if (!this.cache || this.clock() - this.builtAt > CACHE_MAX_AGE_MS) await this.rebuild();
+    if (!this.cache) {
+      // Cold start (or just invalidated): must block until we know the cells.
+      await this.rebuild();
+    } else if (this.clock() - this.cache.builtAt > CACHE_MAX_AGE_MS) {
+      // Stale-while-revalidate: keep serving the current set and refresh in the
+      // background. The .catch keeps a rejected listApps (socket reconnecting,
+      // conductor restarting) from becoming an unhandled rejection or a signing
+      // outage.
+      void this.rebuild().catch(() => {});
+    }
+
     let decision = evaluate();
     if (
       !decision.sign &&
       decision.reason === 'unknown-cell' &&
-      this.clock() - this.builtAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS
+      (!this.cache || this.clock() - this.cache.builtAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS)
     ) {
       await this.rebuild();
       decision = evaluate();
@@ -98,29 +113,29 @@ export class AppletZomeCallAuthorizer {
     if (this.rebuildInFlight) return this.rebuildInFlight;
     const generationAtStart = this.generation;
     const p = (async () => {
-      const apps = await this.listApps();
-      // An invalidate() during the listApps round-trip means this snapshot may
-      // already be stale (e.g. the app it would grant was just uninstalled), so
-      // discard it rather than restore it.
-      if (generationAtStart !== this.generation) return;
-      const ownByAppletId = new Map<string, Set<string>>();
-      const groupCells = new Set<string>();
-      for (const app of apps) {
-        const appId = app.installed_app_id;
-        if (appId.startsWith('applet#')) {
-          ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
-        } else if (appId.startsWith('group#')) {
-          // Only the `group` role cell hosts the profiles zome an applet may call.
-          for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+      try {
+        const apps = await this.listApps();
+        // An invalidate() during the listApps round-trip means this snapshot may
+        // already be stale (e.g. the app it would grant was just uninstalled), so
+        // discard it rather than commit it.
+        if (generationAtStart !== this.generation) return;
+        const ownByAppletId = new Map<string, Set<string>>();
+        const groupCells = new Set<string>();
+        for (const app of apps) {
+          const appId = app.installed_app_id;
+          if (appId.startsWith('applet#')) {
+            ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
+          } else if (appId.startsWith('group#')) {
+            // Only the `group` role cell hosts the profiles zome an applet may call.
+            for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+          }
         }
+        this.cache = { ownByAppletId, groupCells, builtAt: this.clock() };
+      } finally {
+        if (generationAtStart === this.generation) this.rebuildInFlight = undefined;
       }
-      this.cache = { ownByAppletId, groupCells };
-      this.builtAt = this.clock();
     })();
     this.rebuildInFlight = p;
-    void p.finally(() => {
-      if (this.rebuildInFlight === p) this.rebuildInFlight = undefined;
-    });
     return p;
   }
 }

--- a/src/main/appletZomeCallAuthorizer.ts
+++ b/src/main/appletZomeCallAuthorizer.ts
@@ -16,14 +16,15 @@ import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCall
 const CACHE_MAX_AGE_MS = 60_000;
 
 /**
- * Minimum time between rebuilds triggered by an unknown-cell refusal. A rebuild
- * picks up an applet or group installed since the last build, but only once per
- * interval, so a flood of calls to a genuinely-unknown cell cannot drive an
- * unthrottled listApps per call. Legitimate new cells do not depend on this
- * timing: the install IPC handlers call invalidate(), which drops the cache so
- * the next call rebuilds regardless of the interval. The residual case is a cell
- * that appears with no main-process signal (an applet cloning its own DNA over
- * the app websocket) and is called within the interval of the last build.
+ * Minimum time between rebuild *attempts* (see maybeRebuild). A rebuild picks up
+ * an applet or group installed since the last build, but only once per interval,
+ * so a flood of unknown-cell calls — or a rejecting listApps during an outage —
+ * cannot drive an unthrottled round-trip per call. Legitimate new cells do not
+ * depend on this timing: the install IPC handlers call invalidate(), which drops
+ * the cache and resets the attempt clock so the next call rebuilds regardless of
+ * the interval. The residual case is a cell that appears with no main-process
+ * signal (an applet cloning its own DNA over the app websocket) and is called
+ * within the interval of the last build.
  */
 const MIN_UNKNOWN_REBUILD_INTERVAL_MS = 1_000;
 
@@ -62,6 +63,9 @@ export class AppletZomeCallAuthorizer {
     this.cache = undefined;
     this.generation += 1;
     this.rebuildInFlight = undefined;
+    // Allow the next authorize() to rebuild immediately rather than being
+    // rate-limited against the previous attempt.
+    this.lastAttemptAt = -Infinity;
   }
 
   async authorize(
@@ -78,29 +82,40 @@ export class AppletZomeCallAuthorizer {
       });
 
     if (!this.cache) {
-      // Cold start (or just invalidated): must block until we know the cells.
-      await this.rebuild();
-    } else if (
-      this.clock() - this.cache.builtAt > CACHE_MAX_AGE_MS &&
-      this.clock() - this.lastAttemptAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS
-    ) {
-      // Stale-while-revalidate: keep serving the current set and refresh in the
-      // background, at most once per interval. The .catch keeps a rejected
-      // listApps (socket reconnecting, conductor restarting) from becoming an
-      // unhandled rejection, a signing outage, or one doomed round-trip per call.
-      void this.rebuild().catch(() => {});
+      // Cold start (or just invalidated): block until we know the cells. If the
+      // rebuild fails (or is rate-limited during an outage) the cache stays
+      // undefined and we fail closed below.
+      await this.maybeRebuild();
+    } else if (this.clock() - this.cache.builtAt > CACHE_MAX_AGE_MS) {
+      // Stale-while-revalidate: keep serving the current set, refresh in the
+      // background.
+      void this.maybeRebuild();
     }
 
     let decision = evaluate();
-    if (
-      !decision.sign &&
-      decision.reason === 'unknown-cell' &&
-      (!this.cache || this.clock() - this.cache.builtAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS)
-    ) {
-      await this.rebuild();
+    if (!decision.sign && decision.reason === 'unknown-cell') {
+      // Refresh once to pick up a cell installed/cloned since the last build.
+      await this.maybeRebuild();
       decision = evaluate();
     }
     return decision;
+  }
+
+  /**
+   * Rebuild the cache, but at most one *attempt* per interval (whether it
+   * succeeds or fails), and never propagating a failure. This is the one rate
+   * limit and error boundary for all three authorize() call sites: a flood of
+   * unknown-cell calls, or a rejecting listApps during an admin-socket outage,
+   * fires at most one round-trip per interval, and callers always fall through to
+   * a fail-closed decision rather than throwing a raw socket error at the applet.
+   * Concurrent callers coalesce onto the in-flight rebuild.
+   */
+  private maybeRebuild(): Promise<void> {
+    if (this.rebuildInFlight) return this.rebuildInFlight.catch(() => {});
+    if (this.clock() - this.lastAttemptAt <= MIN_UNKNOWN_REBUILD_INTERVAL_MS) {
+      return Promise.resolve();
+    }
+    return this.rebuild().catch(() => {});
   }
 
   /**
@@ -122,6 +137,11 @@ export class AppletZomeCallAuthorizer {
     const generationAtStart = this.generation;
     const p = (async () => {
       try {
+        // Suspend before calling listApps so the `this.rebuildInFlight = p` below
+        // always runs before the body can complete — otherwise a *synchronously*
+        // throwing listApps would leave a rejected promise stored in
+        // rebuildInFlight that every future rebuild() short-circuits onto forever.
+        await Promise.resolve();
         const apps = await this.listApps();
         // An invalidate() during the listApps round-trip means this snapshot may
         // already be stale (e.g. the app it would grant was just uninstalled), so

--- a/src/main/appletZomeCallAuthorizer.ts
+++ b/src/main/appletZomeCallAuthorizer.ts
@@ -1,0 +1,105 @@
+import { AppInfo, CallZomeRequest, CellId, CellInfo, encodeHashToBase64 } from '@holochain/client';
+import { appletIdFromAppId, getCellId } from '@theweave/utils';
+import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCallSigningPolicy';
+
+/**
+ * Resolves which cells each installed applet is allowed to have zome calls signed
+ * for, and decides individual sign requests against that set (via the pure
+ * decideZomeCallSignable policy).
+ *
+ * Resolving the allowed cells is a listApps round-trip and signing is on the hot
+ * path, so the result is cached. The cache is rebuilt lazily: a request that the
+ * cached view would refuse for an *unknown* cell triggers one refresh before the
+ * refusal, so a just-installed applet or group is picked up with no false
+ * rejection; concurrent refreshes coalesce into a single listApps. A known group
+ * cell refused for a non-profiles zome is not re-checked (a rebuild cannot change
+ * that verdict). Callers invalidate() on uninstall so the cache never keeps
+ * granting for an app that is gone.
+ */
+export class AppletZomeCallAuthorizer {
+  private cache: { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string> } | undefined;
+  private rebuildInFlight: Promise<void> | undefined;
+
+  constructor(private listApps: () => Promise<AppInfo[]>) {}
+
+  /** Drop the cached cell sets so the next authorize() re-resolves from live app info. */
+  invalidate(): void {
+    this.cache = undefined;
+  }
+
+  async authorize(
+    callerAppletIds: string[],
+    zomeCall: CallZomeRequest,
+  ): Promise<ZomeCallSigningDecision> {
+    if (!zomeCall.cell_id) return { sign: false, reason: 'unknown-cell' };
+    const evaluate = (): ZomeCallSigningDecision =>
+      decideZomeCallSignable({
+        cellIdB64: cellIdKey(zomeCall.cell_id!),
+        zomeName: zomeCall.zome_name,
+        appletOwnCellIdsB64: this.ownCellsForCallers(callerAppletIds),
+        groupCellIdsB64: this.cache?.groupCells ?? new Set(),
+      });
+
+    if (!this.cache) await this.rebuild();
+    let decision = evaluate();
+    if (!decision.sign && decision.reason === 'unknown-cell') {
+      await this.rebuild();
+      decision = evaluate();
+    }
+    return decision;
+  }
+
+  /**
+   * The union of own-cells across the caller's applet ids. A plain applet caller
+   * passes one id; a cross-group view passes every applet of its tool, so it may
+   * legitimately sign for any of them (but still only their own cells).
+   */
+  private ownCellsForCallers(callerAppletIds: string[]): Set<string> {
+    const union = new Set<string>();
+    for (const id of callerAppletIds) {
+      for (const key of this.cache?.ownByAppletId.get(id) ?? []) union.add(key);
+    }
+    return union;
+  }
+
+  private rebuild(): Promise<void> {
+    if (this.rebuildInFlight) return this.rebuildInFlight;
+    this.rebuildInFlight = (async () => {
+      try {
+        const apps = await this.listApps();
+        const ownByAppletId = new Map<string, Set<string>>();
+        const groupCells = new Set<string>();
+        for (const app of apps) {
+          const appId = app.installed_app_id;
+          if (appId.startsWith('applet#')) {
+            ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
+          } else if (appId.startsWith('group#')) {
+            // Only the `group` role cell hosts the profiles zome an applet may call.
+            for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
+          }
+        }
+        this.cache = { ownByAppletId, groupCells };
+      } finally {
+        this.rebuildInFlight = undefined;
+      }
+    })();
+    return this.rebuildInFlight;
+  }
+}
+
+/** Stable string key for a CellId ([DnaHash, AgentPubKey]) so it can go in a Set. */
+function cellIdKey(cellId: CellId): string {
+  return `${encodeHashToBase64(cellId[0])}|${encodeHashToBase64(cellId[1])}`;
+}
+
+function cellIdsOfApp(appInfo: AppInfo, roleFilter?: string): string[] {
+  const keys: string[] = [];
+  for (const [roleName, cellInfos] of Object.entries(appInfo.cell_info)) {
+    if (roleFilter && roleName !== roleFilter) continue;
+    for (const cellInfo of cellInfos as CellInfo[]) {
+      const cellId = getCellId(cellInfo);
+      if (cellId) keys.push(cellIdKey(cellId));
+    }
+  }
+  return keys;
+}

--- a/src/main/appletZomeCallAuthorizer.ts
+++ b/src/main/appletZomeCallAuthorizer.ts
@@ -47,6 +47,10 @@ export class AppletZomeCallAuthorizer {
     | undefined;
   private generation = 0;
   private rebuildInFlight: Promise<void> | undefined;
+  // When the last rebuild was *attempted* (vs `cache.builtAt` = last success).
+  // Rate-limits background refreshes so a rejecting listApps (admin socket
+  // outage) can't fire one doomed round-trip per authorize call.
+  private lastAttemptAt = -Infinity;
 
   constructor(
     private listApps: () => Promise<AppInfo[]>,
@@ -76,11 +80,14 @@ export class AppletZomeCallAuthorizer {
     if (!this.cache) {
       // Cold start (or just invalidated): must block until we know the cells.
       await this.rebuild();
-    } else if (this.clock() - this.cache.builtAt > CACHE_MAX_AGE_MS) {
+    } else if (
+      this.clock() - this.cache.builtAt > CACHE_MAX_AGE_MS &&
+      this.clock() - this.lastAttemptAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS
+    ) {
       // Stale-while-revalidate: keep serving the current set and refresh in the
-      // background. The .catch keeps a rejected listApps (socket reconnecting,
-      // conductor restarting) from becoming an unhandled rejection or a signing
-      // outage.
+      // background, at most once per interval. The .catch keeps a rejected
+      // listApps (socket reconnecting, conductor restarting) from becoming an
+      // unhandled rejection, a signing outage, or one doomed round-trip per call.
       void this.rebuild().catch(() => {});
     }
 
@@ -111,6 +118,7 @@ export class AppletZomeCallAuthorizer {
 
   private rebuild(): Promise<void> {
     if (this.rebuildInFlight) return this.rebuildInFlight;
+    this.lastAttemptAt = this.clock();
     const generationAtStart = this.generation;
     const p = (async () => {
       try {

--- a/src/main/appletZomeCallAuthorizer.ts
+++ b/src/main/appletZomeCallAuthorizer.ts
@@ -1,6 +1,27 @@
 import { AppInfo, CallZomeRequest, CellId, CellInfo, encodeHashToBase64 } from '@holochain/client';
 import { appletIdFromAppId, getCellId } from '@theweave/utils';
+import type { AppletId } from '@theweave/api';
 import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCallSigningPolicy';
+
+/**
+ * How long a resolved cell set may be trusted before it is rebuilt from live app
+ * info. This is the self-heal window for an uninstall that never called
+ * invalidate() — notably the renderer's leaveGroup, which uninstalls apps
+ * through its own admin websocket and so bypasses the main-process invalidate
+ * sites. Within this window a torn-down applet's cells can still be granted, but
+ * there is no iframe left to request signing for them.
+ */
+const CACHE_MAX_AGE_MS = 60_000;
+
+/**
+ * Minimum time between rebuilds triggered by an unknown-cell refusal. A rebuild
+ * picks up an applet or group installed since the last build (so a legitimate
+ * just-installed cell is not falsely refused), but only once per interval, so a
+ * flood of calls to a genuinely-unknown cell cannot drive an unthrottled
+ * listApps per call. The interval is well below the time it takes a
+ * newly-installed applet's iframe to mount and make its first call.
+ */
+const MIN_UNKNOWN_REBUILD_INTERVAL_MS = 1_000;
 
 /**
  * Resolves which cells each installed applet is allowed to have zome calls signed
@@ -8,27 +29,34 @@ import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCall
  * decideZomeCallSignable policy).
  *
  * Resolving the allowed cells is a listApps round-trip and signing is on the hot
- * path, so the result is cached. The cache is rebuilt lazily: a request that the
- * cached view would refuse for an *unknown* cell triggers one refresh before the
- * refusal, so a just-installed applet or group is picked up with no false
- * rejection; concurrent refreshes coalesce into a single listApps. A known group
- * cell refused for a non-profiles zome is not re-checked (a rebuild cannot change
- * that verdict). Callers invalidate() on uninstall so the cache never keeps
- * granting for an app that is gone.
+ * path, so the result is cached. Freshness is maintained three ways: invalidate()
+ * drops it immediately (called on the IPC uninstall paths); a request that the
+ * cached view refuses for an *unknown* cell rebuilds once (throttled) so a
+ * just-installed cell is picked up; and a cache older than CACHE_MAX_AGE_MS is
+ * rebuilt before use so a missed invalidate self-heals. A generation counter
+ * ensures an invalidate() during an in-flight rebuild discards that rebuild's
+ * (now stale) snapshot instead of silently restoring it.
  */
 export class AppletZomeCallAuthorizer {
   private cache: { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string> } | undefined;
+  private builtAt = 0;
+  private generation = 0;
   private rebuildInFlight: Promise<void> | undefined;
 
-  constructor(private listApps: () => Promise<AppInfo[]>) {}
+  constructor(
+    private listApps: () => Promise<AppInfo[]>,
+    private clock: () => number = () => Date.now(),
+  ) {}
 
-  /** Drop the cached cell sets so the next authorize() re-resolves from live app info. */
+  /** Drop the cached cell sets and abandon any in-flight rebuild's result. */
   invalidate(): void {
     this.cache = undefined;
+    this.generation += 1;
+    this.rebuildInFlight = undefined;
   }
 
   async authorize(
-    callerAppletIds: string[],
+    callerAppletIds: AppletId[],
     zomeCall: CallZomeRequest,
   ): Promise<ZomeCallSigningDecision> {
     if (!zomeCall.cell_id) return { sign: false, reason: 'unknown-cell' };
@@ -40,9 +68,13 @@ export class AppletZomeCallAuthorizer {
         groupCellIdsB64: this.cache?.groupCells ?? new Set(),
       });
 
-    if (!this.cache) await this.rebuild();
+    if (!this.cache || this.clock() - this.builtAt > CACHE_MAX_AGE_MS) await this.rebuild();
     let decision = evaluate();
-    if (!decision.sign && decision.reason === 'unknown-cell') {
+    if (
+      !decision.sign &&
+      decision.reason === 'unknown-cell' &&
+      this.clock() - this.builtAt > MIN_UNKNOWN_REBUILD_INTERVAL_MS
+    ) {
       await this.rebuild();
       decision = evaluate();
     }
@@ -54,7 +86,7 @@ export class AppletZomeCallAuthorizer {
    * passes one id; a cross-group view passes every applet of its tool, so it may
    * legitimately sign for any of them (but still only their own cells).
    */
-  private ownCellsForCallers(callerAppletIds: string[]): Set<string> {
+  private ownCellsForCallers(callerAppletIds: AppletId[]): Set<string> {
     const union = new Set<string>();
     for (const id of callerAppletIds) {
       for (const key of this.cache?.ownByAppletId.get(id) ?? []) union.add(key);
@@ -64,26 +96,32 @@ export class AppletZomeCallAuthorizer {
 
   private rebuild(): Promise<void> {
     if (this.rebuildInFlight) return this.rebuildInFlight;
-    this.rebuildInFlight = (async () => {
-      try {
-        const apps = await this.listApps();
-        const ownByAppletId = new Map<string, Set<string>>();
-        const groupCells = new Set<string>();
-        for (const app of apps) {
-          const appId = app.installed_app_id;
-          if (appId.startsWith('applet#')) {
-            ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
-          } else if (appId.startsWith('group#')) {
-            // Only the `group` role cell hosts the profiles zome an applet may call.
-            for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
-          }
+    const generationAtStart = this.generation;
+    const p = (async () => {
+      const apps = await this.listApps();
+      // An invalidate() during the listApps round-trip means this snapshot may
+      // already be stale (e.g. the app it would grant was just uninstalled), so
+      // discard it rather than restore it.
+      if (generationAtStart !== this.generation) return;
+      const ownByAppletId = new Map<string, Set<string>>();
+      const groupCells = new Set<string>();
+      for (const app of apps) {
+        const appId = app.installed_app_id;
+        if (appId.startsWith('applet#')) {
+          ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
+        } else if (appId.startsWith('group#')) {
+          // Only the `group` role cell hosts the profiles zome an applet may call.
+          for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
         }
-        this.cache = { ownByAppletId, groupCells };
-      } finally {
-        this.rebuildInFlight = undefined;
       }
+      this.cache = { ownByAppletId, groupCells };
+      this.builtAt = this.clock();
     })();
-    return this.rebuildInFlight;
+    this.rebuildInFlight = p;
+    void p.finally(() => {
+      if (this.rebuildInFlight === p) this.rebuildInFlight = undefined;
+    });
+    return p;
   }
 }
 

--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -173,37 +173,49 @@ export class HolochainManager {
     conductorHandle.stdin.write(password);
     conductorHandle.stdin.end();
 
-    // Inactivity backstop for a conductor that hangs without ever becoming ready
-    // and without exiting. It measures silence, not total time, so a slow but
-    // progressing first-run migration + WASM compile (which keeps logging) is not
-    // killed; deterministic failures (crash / bad config / port conflict) are
-    // caught by the exit + error listeners, not by this timer.
+    // Two backstops for a conductor that never becomes ready. The inactivity
+    // timer measures silence, not total time, so a slow but progressing first-run
+    // migration + WASM compile (which keeps logging) is not killed. The absolute
+    // cap catches the opposite failure the inactivity timer cannot see — a
+    // conductor that keeps logging but never prints 'Conductor ready.' (a pre-ready
+    // retry loop, or a reworded magic string). Deterministic failures (crash / bad
+    // config / port conflict) are caught by the exit + error listeners.
     const LAUNCH_INACTIVITY_TIMEOUT_MS = 300_000;
+    const LAUNCH_ABSOLUTE_TIMEOUT_MS = 20 * 60_000;
 
     return new Promise((resolve, reject) => {
       // A conductor process can fail to spawn ('error'), or exit before
       // 'Conductor ready.' with a message that matches neither magic string
-      // below (a lost port race, an incompatible database), or go silent without
-      // becoming ready — all of which must settle this Promise rather than leave
-      // the UI waiting at "starting Holochain...". `settled` guards against
-      // double-settling; a failed launch also kills the process so it cannot
-      // linger holding the admin port and SQLite locks.
+      // below (a lost port race, an incompatible database), or never become ready
+      // (silent, or logging-but-stuck) — all of which must settle this Promise
+      // rather than leave the UI waiting at "starting Holochain...". `settled`
+      // guards against double-settling; a failed launch also kills the process so
+      // it cannot linger holding the admin port and SQLite locks.
       let settled = false;
+      let readyHandled = false;
       let inactivityTimer: ReturnType<typeof setTimeout>;
+      const absoluteTimer = setTimeout(() => {
+        finishErr(
+          `Holochain did not become ready within ${LAUNCH_ABSOLUTE_TIMEOUT_MS / 60_000} minutes. Check the logs for details (Help > Open Logs).`,
+        );
+      }, LAUNCH_ABSOLUTE_TIMEOUT_MS);
       const finishOk = (manager: HolochainManager) => {
         if (settled) return;
         settled = true;
         clearTimeout(inactivityTimer);
+        clearTimeout(absoluteTimer);
         resolve(manager);
       };
       const finishErr = (message: string) => {
         if (settled) return;
         settled = true;
         clearTimeout(inactivityTimer);
+        clearTimeout(absoluteTimer);
         conductorHandle.kill();
         reject(message);
       };
       // Restart the silence timer on any output; startup progress keeps it alive.
+      // Only while unsettled, so it stops once the conductor is up and logging.
       const armInactivityTimer = () => {
         clearTimeout(inactivityTimer);
         inactivityTimer = setTimeout(() => {
@@ -228,7 +240,7 @@ export class HolochainManager {
       });
 
       conductorHandle.stdout.pipe(split()).on('data', async (line: string) => {
-        armInactivityTimer();
+        if (!settled) armInactivityTimer();
         weEmitter.emitHolochainLog({
           version,
           data: line,
@@ -240,8 +252,12 @@ export class HolochainManager {
         }
         if (line.includes('Conductor ready.')) {
           // Guard against a second matching line opening a second admin websocket
-          // and attaching a second post-startup exit listener.
-          if (settled) return;
+          // and attaching a second post-startup exit listener. `readyHandled` is
+          // set synchronously here because `settled` is not set until the async
+          // connect sequence below completes — a second line arriving mid-connect
+          // would otherwise pass a `settled`-only check.
+          if (settled || readyHandled) return;
+          readyHandled = true;
           console.log(
             `[MOSS] Detected 'Conductor ready.' on stdout. Connecting to admin port ${adminPort}...`,
           );
@@ -295,7 +311,7 @@ export class HolochainManager {
         }
       });
       conductorHandle.stderr.pipe(split()).on('data', (line: string) => {
-        armInactivityTimer();
+        if (!settled) armInactivityTimer();
         weEmitter.emitHolochainError({
           version,
           data: line,

--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -170,6 +170,10 @@ export class HolochainManager {
     const conductorHandle = childProcess.spawn(binary, ['-c', configPath, '-p'], {
       env: conductorEnv,
     });
+    // Without a stdin 'error' handler, a spawn failure (missing/incompatible
+    // binary) can surface as an uncaught EPIPE/ERR_STREAM_DESTROYED that crashes
+    // main before the process 'error' listener turns it into a clean rejection.
+    conductorHandle.stdin.on('error', () => {});
     conductorHandle.stdin.write(password);
     conductorHandle.stdin.end();
 
@@ -180,7 +184,11 @@ export class HolochainManager {
     // conductor that keeps logging but never prints 'Conductor ready.' (a pre-ready
     // retry loop, or a reworded magic string). Deterministic failures (crash / bad
     // config / port conflict) are caught by the exit + error listeners.
-    const LAUNCH_INACTIVITY_TIMEOUT_MS = 300_000;
+    // Silence is only meant to catch a true hang, and a healthy first-run
+    // migration + WASM compile can legitimately log nothing above `warn` (the
+    // chattiest startup targets are demoted to `error`) for a while — so this is
+    // deliberately long; the absolute cap is the real deadline.
+    const LAUNCH_INACTIVITY_TIMEOUT_MS = 10 * 60_000;
     const LAUNCH_ABSOLUTE_TIMEOUT_MS = 20 * 60_000;
 
     return new Promise((resolve, reject) => {
@@ -261,8 +269,9 @@ export class HolochainManager {
           console.log(
             `[MOSS] Detected 'Conductor ready.' on stdout. Connecting to admin port ${adminPort}...`,
           );
+          let adminWebsocket: AdminWebsocket | undefined;
           try {
-            const adminWebsocket = await AdminWebsocket.connect({
+            adminWebsocket = await AdminWebsocket.connect({
               url: new URL(`ws://127.0.0.1:${adminPort}`),
               wsClientOptions: {
                 origin: 'moss://admin.main',
@@ -281,6 +290,14 @@ export class HolochainManager {
               });
               console.log('Attached app interface port: ', attachAppInterfaceResponse);
               appPort = attachAppInterfaceResponse.port;
+            }
+            // A timer may have already failed (and killed) the launch while this
+            // connect sequence was awaiting. Don't build a manager or attach a
+            // crash listener against a conductor that is being torn down, and
+            // close the websocket we just opened so it doesn't leak.
+            if (settled) {
+              adminWebsocket.client.close();
+              return;
             }
             const manager = new HolochainManager(
               conductorHandle,
@@ -306,6 +323,13 @@ export class HolochainManager {
             });
             finishOk(manager);
           } catch (e) {
+            // Close the websocket if it opened before a later step threw, so a
+            // failed connect doesn't leak a socket against the conductor we kill.
+            try {
+              adminWebsocket?.client.close();
+            } catch {
+              // ignore
+            }
             finishErr(`Holochain conductor ready but failed to connect: ${e}`);
           }
         }

--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -161,14 +161,67 @@ export class HolochainManager {
     conductorHandle.stdin.write(password);
     conductorHandle.stdin.end();
 
+    // Backstop for a conductor that never prints 'Conductor ready.' and never
+    // exits (a true hang). Generous so a slow first-run WASM compile does not
+    // trip it; the deterministic failures (crash / bad config / port conflict)
+    // are caught by the exit + error listeners below, not by this timer.
+    const LAUNCH_TIMEOUT_MS = 300_000;
+
     return new Promise((resolve, reject) => {
+      // A conductor process can fail in three ways this Promise must settle on,
+      // none of which the log-string matches below cover: it can fail to spawn
+      // ('error'), or exit before 'Conductor ready.' with a message that matches
+      // neither magic string (a lost port race, an incompatible database) — both
+      // of which previously left this Promise pending forever, hanging the UI at
+      // "starting Holochain...". `settled` guards against double-settling and
+      // also distinguishes a pre-ready exit (reject) from a post-ready crash
+      // (surface to the renderer; the Promise is long resolved).
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        reject(
+          `Holochain did not become ready within ${LAUNCH_TIMEOUT_MS / 1000}s. Check the logs for details (Help > Open Logs).`,
+        );
+      }, LAUNCH_TIMEOUT_MS);
+      const finishOk = (manager: HolochainManager) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(manager);
+      };
+      const finishErr = (message: string) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(message);
+      };
+
+      conductorHandle.on('error', (err) => {
+        finishErr(`Failed to launch the Holochain conductor process: ${err}`);
+      });
+      conductorHandle.on('exit', (code, signal) => {
+        if (!settled) {
+          finishErr(
+            `Holochain conductor exited during startup (code ${code}, signal ${signal}) before becoming ready. Check the logs for details (Help > Open Logs).`,
+          );
+          return;
+        }
+        // Crashed after a successful startup: the Promise is already resolved, so
+        // surface it to the renderer rather than dropping it silently.
+        weEmitter.emitHolochainFatalPanic({
+          version,
+          data: `Holochain conductor exited after startup (code ${code}, signal ${signal}).`,
+        });
+      });
+
       conductorHandle.stdout.pipe(split()).on('data', async (line: string) => {
         weEmitter.emitHolochainLog({
           version,
           data: line,
         });
         if (line.includes('could not be parsed, because it is not valid YAML')) {
-          reject(
+          finishErr(
             `Holochain failed to start up and crashed. Check the logs for details (Help > Open Logs).`,
           );
         }
@@ -197,7 +250,7 @@ export class HolochainManager {
               console.log('Attached app interface port: ', attachAppInterfaceResponse);
               appPort = attachAppInterfaceResponse.port;
             }
-            resolve(
+            finishOk(
               new HolochainManager(
                 conductorHandle,
                 weEmitter,
@@ -210,7 +263,7 @@ export class HolochainManager {
               ),
             );
           } catch (e) {
-            reject(`Holochain conductor ready but failed to connect: ${e}`);
+            finishErr(`Holochain conductor ready but failed to connect: ${e}`);
           }
         }
       });
@@ -220,7 +273,7 @@ export class HolochainManager {
           data: line,
         });
         if (line.includes('holochain had a problem and crashed')) {
-          reject(
+          finishErr(
             `Holochain failed to start up and crashed. Check the logs for details (Help > Open Logs).`,
           );
         }

--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -26,6 +26,9 @@ export class HolochainManager {
   weEmitter: WeEmitter;
   version: HolochainVersion;
   appTokens: Record<InstalledAppId, AppAuthenticationToken> = {};
+  // Set when the conductor is being deliberately stopped, so its process 'exit'
+  // is not mistaken for a crash (see the post-startup exit listener in launch()).
+  shuttingDown = false;
 
   constructor(
     processHandle: childProcess.ChildProcessWithoutNullStreams,
@@ -45,6 +48,15 @@ export class HolochainManager {
     this.fs = mossFileSystem;
     this.installedApps = installedApps;
     this.version = version;
+  }
+
+  /**
+   * Deliberately stop the conductor. Marks the stop as intentional first so the
+   * process 'exit' is not reported as a crash, then kills the process.
+   */
+  shutdown(): void {
+    this.shuttingDown = true;
+    this.processHandle.kill();
   }
 
   static async launch(
@@ -168,19 +180,16 @@ export class HolochainManager {
     const LAUNCH_TIMEOUT_MS = 300_000;
 
     return new Promise((resolve, reject) => {
-      // A conductor process can fail in three ways this Promise must settle on,
-      // none of which the log-string matches below cover: it can fail to spawn
-      // ('error'), or exit before 'Conductor ready.' with a message that matches
-      // neither magic string (a lost port race, an incompatible database) — both
-      // of which previously left this Promise pending forever, hanging the UI at
-      // "starting Holochain...". `settled` guards against double-settling and
-      // also distinguishes a pre-ready exit (reject) from a post-ready crash
-      // (surface to the renderer; the Promise is long resolved).
+      // A conductor process can fail to spawn ('error'), or exit before
+      // 'Conductor ready.' with a message that matches neither magic string
+      // below (a lost port race, an incompatible database), or hang without ever
+      // becoming ready — all of which must settle this Promise rather than leave
+      // the UI waiting at "starting Holochain...". `settled` guards against
+      // double-settling; a failed launch also kills the process so it cannot
+      // linger holding the admin port and SQLite locks.
       let settled = false;
       const timeout = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        reject(
+        finishErr(
           `Holochain did not become ready within ${LAUNCH_TIMEOUT_MS / 1000}s. Check the logs for details (Help > Open Logs).`,
         );
       }, LAUNCH_TIMEOUT_MS);
@@ -194,25 +203,21 @@ export class HolochainManager {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
+        conductorHandle.kill();
         reject(message);
       };
 
       conductorHandle.on('error', (err) => {
         finishErr(`Failed to launch the Holochain conductor process: ${err}`);
       });
+      // Only the pre-ready exit is handled here. A post-startup exit is handled
+      // by the manager-aware listener attached once launch succeeds (below),
+      // which can tell a deliberate shutdown from a crash.
       conductorHandle.on('exit', (code, signal) => {
-        if (!settled) {
-          finishErr(
-            `Holochain conductor exited during startup (code ${code}, signal ${signal}) before becoming ready. Check the logs for details (Help > Open Logs).`,
-          );
-          return;
-        }
-        // Crashed after a successful startup: the Promise is already resolved, so
-        // surface it to the renderer rather than dropping it silently.
-        weEmitter.emitHolochainFatalPanic({
-          version,
-          data: `Holochain conductor exited after startup (code ${code}, signal ${signal}).`,
-        });
+        if (settled) return;
+        finishErr(
+          `Holochain conductor exited during startup (code ${code}, signal ${signal}) before becoming ready. Check the logs for details (Help > Open Logs).`,
+        );
       });
 
       conductorHandle.stdout.pipe(split()).on('data', async (line: string) => {
@@ -250,18 +255,27 @@ export class HolochainManager {
               console.log('Attached app interface port: ', attachAppInterfaceResponse);
               appPort = attachAppInterfaceResponse.port;
             }
-            finishOk(
-              new HolochainManager(
-                conductorHandle,
-                weEmitter,
-                mossFileSystem,
-                adminPort,
-                appPort,
-                adminWebsocket,
-                installedApps,
-                version,
-              ),
+            const manager = new HolochainManager(
+              conductorHandle,
+              weEmitter,
+              mossFileSystem,
+              adminPort,
+              appPort,
+              adminWebsocket,
+              installedApps,
+              version,
             );
+            // Report a crash after a successful startup, but not a deliberate
+            // stop (quit / restart / factory reset, which set `shuttingDown`).
+            // MOSS_ERROR is used because it has a subscriber (logs.ts); the
+            // fatal-panic channel has none, so it would drop the report.
+            conductorHandle.on('exit', (code, signal) => {
+              if (manager.shuttingDown) return;
+              weEmitter.emitMossError(
+                `Holochain conductor (v${version}) exited unexpectedly after startup (code ${code}, signal ${signal}).`,
+              );
+            });
+            finishOk(manager);
           } catch (e) {
             finishErr(`Holochain conductor ready but failed to connect: ${e}`);
           }

--- a/src/main/holochainManager.ts
+++ b/src/main/holochainManager.ts
@@ -173,46 +173,53 @@ export class HolochainManager {
     conductorHandle.stdin.write(password);
     conductorHandle.stdin.end();
 
-    // Backstop for a conductor that never prints 'Conductor ready.' and never
-    // exits (a true hang). Generous so a slow first-run WASM compile does not
-    // trip it; the deterministic failures (crash / bad config / port conflict)
-    // are caught by the exit + error listeners below, not by this timer.
-    const LAUNCH_TIMEOUT_MS = 300_000;
+    // Inactivity backstop for a conductor that hangs without ever becoming ready
+    // and without exiting. It measures silence, not total time, so a slow but
+    // progressing first-run migration + WASM compile (which keeps logging) is not
+    // killed; deterministic failures (crash / bad config / port conflict) are
+    // caught by the exit + error listeners, not by this timer.
+    const LAUNCH_INACTIVITY_TIMEOUT_MS = 300_000;
 
     return new Promise((resolve, reject) => {
       // A conductor process can fail to spawn ('error'), or exit before
       // 'Conductor ready.' with a message that matches neither magic string
-      // below (a lost port race, an incompatible database), or hang without ever
+      // below (a lost port race, an incompatible database), or go silent without
       // becoming ready — all of which must settle this Promise rather than leave
       // the UI waiting at "starting Holochain...". `settled` guards against
       // double-settling; a failed launch also kills the process so it cannot
       // linger holding the admin port and SQLite locks.
       let settled = false;
-      const timeout = setTimeout(() => {
-        finishErr(
-          `Holochain did not become ready within ${LAUNCH_TIMEOUT_MS / 1000}s. Check the logs for details (Help > Open Logs).`,
-        );
-      }, LAUNCH_TIMEOUT_MS);
+      let inactivityTimer: ReturnType<typeof setTimeout>;
       const finishOk = (manager: HolochainManager) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timeout);
+        clearTimeout(inactivityTimer);
         resolve(manager);
       };
       const finishErr = (message: string) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timeout);
+        clearTimeout(inactivityTimer);
         conductorHandle.kill();
         reject(message);
       };
+      // Restart the silence timer on any output; startup progress keeps it alive.
+      const armInactivityTimer = () => {
+        clearTimeout(inactivityTimer);
+        inactivityTimer = setTimeout(() => {
+          finishErr(
+            `Holochain produced no output for ${LAUNCH_INACTIVITY_TIMEOUT_MS / 1000}s and never became ready. Check the logs for details (Help > Open Logs).`,
+          );
+        }, LAUNCH_INACTIVITY_TIMEOUT_MS);
+      };
+      armInactivityTimer();
 
       conductorHandle.on('error', (err) => {
         finishErr(`Failed to launch the Holochain conductor process: ${err}`);
       });
-      // Only the pre-ready exit is handled here. A post-startup exit is handled
-      // by the manager-aware listener attached once launch succeeds (below),
-      // which can tell a deliberate shutdown from a crash.
+      // A pre-ready exit rejects the launch. A post-startup exit is judged by a
+      // separate listener attached once the manager exists, because there it must
+      // distinguish a deliberate shutdown from a crash.
       conductorHandle.on('exit', (code, signal) => {
         if (settled) return;
         finishErr(
@@ -221,6 +228,7 @@ export class HolochainManager {
       });
 
       conductorHandle.stdout.pipe(split()).on('data', async (line: string) => {
+        armInactivityTimer();
         weEmitter.emitHolochainLog({
           version,
           data: line,
@@ -231,6 +239,9 @@ export class HolochainManager {
           );
         }
         if (line.includes('Conductor ready.')) {
+          // Guard against a second matching line opening a second admin websocket
+          // and attaching a second post-startup exit listener.
+          if (settled) return;
           console.log(
             `[MOSS] Detected 'Conductor ready.' on stdout. Connecting to admin port ${adminPort}...`,
           );
@@ -267,8 +278,10 @@ export class HolochainManager {
             );
             // Report a crash after a successful startup, but not a deliberate
             // stop (quit / restart / factory reset, which set `shuttingDown`).
-            // MOSS_ERROR is used because it has a subscriber (logs.ts); the
-            // fatal-panic channel has none, so it would drop the report.
+            // Emit on MOSS_ERROR so the crash reaches the log subscriber.
+            // TODO: also surface this to the renderer — the UI currently keeps
+            // rendering against a dead conductor and every zome call fails
+            // opaquely; there is no user-facing "conductor stopped" notification.
             conductorHandle.on('exit', (code, signal) => {
               if (manager.shuttingDown) return;
               weEmitter.emitMossError(
@@ -282,6 +295,7 @@ export class HolochainManager {
         }
       });
       conductorHandle.stderr.pipe(split()).on('data', (line: string) => {
+        armInactivityTimer();
         weEmitter.emitHolochainError({
           version,
           data: line,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -577,8 +577,8 @@ if (!RUNNING_WITH_COMMAND) {
 
   // Scopes applet-requested signing to each applet's own cells + group profiles.
   // Reads live app info lazily via the admin websocket (set during launch); its
-  // cache is invalidated when an applet is uninstalled so it never keeps granting
-  // for a cell whose app is gone.
+  // cache is invalidated on app enable/uninstall so a just-installed cell is
+  // grantable at once and a gone cell is never granted.
   const appletZomeCallAuthorizer = new AppletZomeCallAuthorizer(() =>
     HOLOCHAIN_MANAGER!.adminWebsocket.listApps({}),
   );
@@ -1162,6 +1162,10 @@ if (!RUNNING_WITH_COMMAND) {
 
   function registerIPCHandlers(notificationIcon: Electron.NativeImage) {
     ipcMain.handle('exit', () => {
+      // app.exit(0) skips the before-quit handler, so stop the subprocesses here
+      // or they survive as orphans holding the admin port and keystore.
+      if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.shutdown();
+      if (LAIR_HANDLE) LAIR_HANDLE.kill();
       app.exit(0);
     });
     ipcMain.handle('open-logs', async () => WE_FILE_SYSTEM.openLogs());
@@ -1807,6 +1811,7 @@ if (!RUNNING_WITH_COMMAND) {
           });
         }
         await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
+        appletZomeCallAuthorizer.invalidate();
         setTimeout(
           () =>
             autoSaveGroupsExport().catch((e) =>
@@ -2082,6 +2087,7 @@ if (!RUNNING_WITH_COMMAND) {
             },
           });
           await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
+          appletZomeCallAuthorizer.invalidate();
 
           const token = await HOLOCHAIN_MANAGER!.getAppToken(appId);
           const appWs = await AppWebsocket.connect({
@@ -2388,6 +2394,7 @@ if (!RUNNING_WITH_COMMAND) {
         console.log('Determined appId for group: ', appId);
         if (apps.map((appInfo) => appInfo.installed_app_id).includes(appId)) {
           await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
+          appletZomeCallAuthorizer.invalidate();
           const appInfo = apps.find((appInfo) => appInfo.installed_app_id === appId);
           if (!appInfo) throw new Error('AppInfo undefined.');
           return appInfo;
@@ -2417,6 +2424,7 @@ if (!RUNNING_WITH_COMMAND) {
           },
         });
         await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
+        appletZomeCallAuthorizer.invalidate();
         setTimeout(
           () =>
             autoSaveGroupsExport().catch((e) =>
@@ -3033,6 +3041,7 @@ if (!RUNNING_WITH_COMMAND) {
         // Enable the app after storing metadata in case enabling fails
         try {
           await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
+          appletZomeCallAuthorizer.invalidate();
         } catch (e) {
           // If the app failed to get enabled due to a reason other than awaiting memproofs, log it
           // but continue. The app would then need to get enabled in the UI.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -84,8 +84,6 @@ import {
   AppWebsocket,
   CallZomeRequest,
   CallZomeTransform,
-  CellId,
-  CellInfo,
   CellType,
   DnaHashB64,
   InstalledAppId,
@@ -113,14 +111,13 @@ import { type WeRustHandler } from '@lightningrodlabs/we-rust-utils';
 import {
   appletIdFromAppId,
   deriveToolCompatibilityId,
-  getCellId,
   globalPubKeyFromListAppsResponse,
   isWeaveUrl,
   toLowerCaseB64,
   toolCompatibilityIdFromDistInfo,
   toOriginalCaseB64,
 } from '@theweave/utils';
-import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCallSigningPolicy';
+import { AppletZomeCallAuthorizer } from './appletZomeCallAuthorizer';
 import { sortVersionsDescending } from './utils';
 import { Profile as AgentProfile } from '@holochain-open-dev/profiles';
 import { Jimp } from 'jimp';
@@ -578,95 +575,13 @@ if (!RUNNING_WITH_COMMAND) {
     return signZomeCall(zomeCall, WE_RUST_HANDLER, WE_EMITTER);
   };
 
-  // Stable string key for a CellId ([DnaHash, AgentPubKey]) so it can go in a Set.
-  const cellIdKey = (cellId: CellId): string =>
-    `${encodeHashToBase64(cellId[0])}|${encodeHashToBase64(cellId[1])}`;
-
-  const cellIdsOfApp = (appInfo: AppInfo, roleFilter?: string): string[] => {
-    const keys: string[] = [];
-    for (const [roleName, cellInfos] of Object.entries(appInfo.cell_info)) {
-      if (roleFilter && roleName !== roleFilter) continue;
-      for (const cellInfo of cellInfos as CellInfo[]) {
-        const cellId = getCellId(cellInfo);
-        if (cellId) keys.push(cellIdKey(cellId));
-      }
-    }
-    return keys;
-  };
-
-  // Cache of the cells an applet is allowed to have signed. Resolving these means
-  // a listApps round-trip, and signing is on the hot path, so results are cached.
-  // A miss (the decision below says "no") always refreshes once before the call
-  // is refused, so a just-installed applet or group is picked up immediately with
-  // no false rejection; concurrent refreshes are coalesced into one listApps.
-  let appletCellCache:
-    | { ownByAppletId: Map<string, Set<string>>; groupCells: Set<string> }
-    | undefined;
-  let cacheRebuildInFlight: Promise<void> | undefined;
-
-  const rebuildAppletCellCache = (): Promise<void> => {
-    if (cacheRebuildInFlight) return cacheRebuildInFlight;
-    cacheRebuildInFlight = (async () => {
-      try {
-        const apps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});
-        const ownByAppletId = new Map<string, Set<string>>();
-        const groupCells = new Set<string>();
-        for (const app of apps) {
-          const appId = app.installed_app_id;
-          if (appId.startsWith('applet#')) {
-            ownByAppletId.set(appletIdFromAppId(appId), new Set(cellIdsOfApp(app)));
-          } else if (appId.startsWith('group#')) {
-            // Only the `group` role cell hosts the profiles zome an applet may call.
-            for (const key of cellIdsOfApp(app, 'group')) groupCells.add(key);
-          }
-        }
-        appletCellCache = { ownByAppletId, groupCells };
-      } finally {
-        cacheRebuildInFlight = undefined;
-      }
-    })();
-    return cacheRebuildInFlight;
-  };
-
-  // The union of own-cells across the caller's applet ids. A plain applet caller
-  // passes one id; a cross-group view passes every applet of its tool, so it may
-  // legitimately sign for any of them (but still only their own cells).
-  const ownCellsForCallers = (callerAppletIds: AppletId[]): Set<string> => {
-    const union = new Set<string>();
-    for (const id of callerAppletIds) {
-      for (const key of appletCellCache?.ownByAppletId.get(id) ?? []) union.add(key);
-    }
-    return union;
-  };
-
-  // Decide whether to sign, rebuilding the cache once if a first look says no —
-  // covers the case where the applet or a group was installed since the last build.
-  const authorizeAppletZomeCall = async (
-    callerAppletIds: AppletId[],
-    zomeCall: CallZomeRequest,
-  ): Promise<ZomeCallSigningDecision> => {
-    if (!zomeCall.cell_id) return { sign: false, reason: 'unknown-cell' };
-    const evaluate = (): ZomeCallSigningDecision =>
-      decideZomeCallSignable({
-        cellIdB64: cellIdKey(zomeCall.cell_id!),
-        zomeName: zomeCall.zome_name,
-        appletOwnCellIdsB64: ownCellsForCallers(callerAppletIds),
-        groupCellIdsB64: appletCellCache?.groupCells ?? new Set(),
-      });
-
-    if (!appletCellCache) await rebuildAppletCellCache();
-    let decision = evaluate();
-    // Refresh once before refusing only when the cell is simply unknown — it may
-    // belong to an applet or group installed since the cache was last built. A
-    // known group cell refused for a non-profiles zome cannot become allowed by
-    // a rebuild, so don't pay a listApps round-trip for those (a misbehaving
-    // applet could otherwise trigger one per rejected call).
-    if (!decision.sign && decision.reason === 'unknown-cell') {
-      await rebuildAppletCellCache();
-      decision = evaluate();
-    }
-    return decision;
-  };
+  // Scopes applet-requested signing to each applet's own cells + group profiles.
+  // Reads live app info lazily via the admin websocket (set during launch); its
+  // cache is invalidated when an applet is uninstalled so it never keeps granting
+  // for a cell whose app is gone.
+  const appletZomeCallAuthorizer = new AppletZomeCallAuthorizer(() =>
+    HOLOCHAIN_MANAGER!.adminWebsocket.listApps({}),
+  );
 
   const handleSignZomeCallApplet = async (
     _e: IpcMainInvokeEvent,
@@ -678,7 +593,7 @@ if (!RUNNING_WITH_COMMAND) {
     if (!Array.isArray(callerAppletIds) || callerAppletIds.length === 0)
       throw Error('sign-zome-call-applet requires the requesting applet id(s).');
 
-    const decision = await authorizeAppletZomeCall(callerAppletIds, zomeCall);
+    const decision = await appletZomeCallAuthorizer.authorize(callerAppletIds, zomeCall);
     if (!decision.sign) {
       throw Error(
         `Refusing to sign zome call for applet(s) ${callerAppletIds.join(', ')}: ${decision.reason}. An applet may only sign calls to its own cells and to the profiles zome of a group cell.`,
@@ -2844,6 +2759,7 @@ if (!RUNNING_WITH_COMMAND) {
       await HOLOCHAIN_MANAGER!.adminWebsocket.uninstallApp({
         installed_app_id: appId,
       });
+      appletZomeCallAuthorizer.invalidate();
       try {
         WE_FILE_SYSTEM.deleteAppMetaDataDir(appId);
       } catch (e: any) {
@@ -3145,6 +3061,7 @@ if (!RUNNING_WITH_COMMAND) {
       await HOLOCHAIN_MANAGER!.adminWebsocket.uninstallApp({
         installed_app_id: appId,
       });
+      appletZomeCallAuthorizer.invalidate();
       WE_FILE_SYSTEM.deleteAppMetaDataDir(appId);
     });
     ipcMain.handle('launch', async (_e): Promise<boolean> => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -583,6 +583,15 @@ if (!RUNNING_WITH_COMMAND) {
     HOLOCHAIN_MANAGER!.adminWebsocket.listApps({}),
   );
 
+  // Enable an app and refresh the signing scope in one step. Enabling changes the
+  // set of callable cells, so every enable site must invalidate the authorizer;
+  // routing them all through here keeps that pairing in one place instead of
+  // relying on each call site to remember it.
+  const enableAppAndInvalidate = async (installedAppId: string): Promise<void> => {
+    await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: installedAppId });
+    appletZomeCallAuthorizer.invalidate();
+  };
+
   const handleSignZomeCallApplet = async (
     _e: IpcMainInvokeEvent,
     zomeCall: CallZomeRequest,
@@ -1550,7 +1559,10 @@ if (!RUNNING_WITH_COMMAND) {
         if (!appId || appId === '') {
           throw new Error('No app id provided.');
         }
+        // installApp enables internally (bypassing enableAppAndInvalidate), and
+        // appId is arbitrary — refresh the signing scope in case it is an applet.
         await HOLOCHAIN_MANAGER!.installApp(filePath, appId, networkSeed);
+        appletZomeCallAuthorizer.invalidate();
       },
     );
     ipcMain.handle('is-dev-mode-enabled', (_e): boolean => !app.isPackaged || RUN_OPTIONS.dev);
@@ -1810,8 +1822,7 @@ if (!RUNNING_WITH_COMMAND) {
             },
           });
         }
-        await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
-        appletZomeCallAuthorizer.invalidate();
+        await enableAppAndInvalidate(appId);
         setTimeout(
           () =>
             autoSaveGroupsExport().catch((e) =>
@@ -2086,8 +2097,7 @@ if (!RUNNING_WITH_COMMAND) {
               group: { type: 'provisioned', value: { modifiers: { properties } } },
             },
           });
-          await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
-          appletZomeCallAuthorizer.invalidate();
+          await enableAppAndInvalidate(appId);
 
           const token = await HOLOCHAIN_MANAGER!.getAppToken(appId);
           const appWs = await AppWebsocket.connect({
@@ -2313,9 +2323,7 @@ if (!RUNNING_WITH_COMMAND) {
                     agent_key: myPubKey,
                     network_seed: toolNetworkSeed,
                   });
-                  await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({
-                    installed_app_id: appletAppId,
-                  });
+                  await enableAppAndInvalidate(appletAppId);
 
                   appletAgentPubKey = appletAppInfo.agent_pub_key;
                 }
@@ -2393,8 +2401,7 @@ if (!RUNNING_WITH_COMMAND) {
         const appId = `group#${hashedSeed}#${progenitor}`;
         console.log('Determined appId for group: ', appId);
         if (apps.map((appInfo) => appInfo.installed_app_id).includes(appId)) {
-          await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
-          appletZomeCallAuthorizer.invalidate();
+          await enableAppAndInvalidate(appId);
           const appInfo = apps.find((appInfo) => appInfo.installed_app_id === appId);
           if (!appInfo) throw new Error('AppInfo undefined.');
           return appInfo;
@@ -2423,8 +2430,7 @@ if (!RUNNING_WITH_COMMAND) {
             },
           },
         });
-        await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
-        appletZomeCallAuthorizer.invalidate();
+        await enableAppAndInvalidate(appId);
         setTimeout(
           () =>
             autoSaveGroupsExport().catch((e) =>
@@ -3040,8 +3046,7 @@ if (!RUNNING_WITH_COMMAND) {
 
         // Enable the app after storing metadata in case enabling fails
         try {
-          await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: appId });
-          appletZomeCallAuthorizer.invalidate();
+          await enableAppAndInvalidate(appId);
         } catch (e) {
           // If the app failed to get enabled due to a reason other than awaiting memproofs, log it
           // but continue. The app would then need to get enabled in the UI.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -583,10 +583,11 @@ if (!RUNNING_WITH_COMMAND) {
     HOLOCHAIN_MANAGER!.adminWebsocket.listApps({}),
   );
 
-  // Enable an app and refresh the signing scope in one step. Enabling changes the
-  // set of callable cells, so every enable site must invalidate the authorizer;
-  // routing them all through here keeps that pairing in one place instead of
-  // relying on each call site to remember it.
+  // Enable an app and refresh the signing scope in one step: enabling widens the
+  // set of callable cells, so the authorizer must re-resolve. Routing every
+  // IPC-reachable enable through here keeps the pairing in one place. (The
+  // install-app handler invalidates directly, since HolochainManager.installApp
+  // enables internally.)
   const enableAppAndInvalidate = async (installedAppId: string): Promise<void> => {
     await HOLOCHAIN_MANAGER!.adminWebsocket.enableApp({ installed_app_id: installedAppId });
     appletZomeCallAuthorizer.invalidate();
@@ -1172,9 +1173,11 @@ if (!RUNNING_WITH_COMMAND) {
   function registerIPCHandlers(notificationIcon: Electron.NativeImage) {
     ipcMain.handle('exit', () => {
       // app.exit(0) skips the before-quit handler, so stop the subprocesses here
-      // or they survive as orphans holding the admin port and keystore.
+      // or they survive as orphans holding the admin port and keystore. (Anything
+      // still unassigned during the launch window can't be stopped from here.)
       if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.shutdown();
       if (LAIR_HANDLE) LAIR_HANDLE.kill();
+      if (LOCAL_SERVICES_HANDLE) LOCAL_SERVICES_HANDLE.kill();
       app.exit(0);
     });
     ipcMain.handle('open-logs', async () => WE_FILE_SYSTEM.openLogs());
@@ -1559,8 +1562,8 @@ if (!RUNNING_WITH_COMMAND) {
         if (!appId || appId === '') {
           throw new Error('No app id provided.');
         }
-        // installApp enables internally (bypassing enableAppAndInvalidate), and
-        // appId is arbitrary — refresh the signing scope in case it is an applet.
+        // installApp enables internally, and appId is arbitrary — refresh the
+        // signing scope in case it is an applet.
         await HOLOCHAIN_MANAGER!.installApp(filePath, appId, networkSeed);
         appletZomeCallAuthorizer.invalidate();
       },
@@ -3088,6 +3091,8 @@ if (!RUNNING_WITH_COMMAND) {
         password,
         RUN_OPTIONS,
       );
+      // A (re)launch replaces the conductor, so any cached signing scope is stale.
+      appletZomeCallAuthorizer.invalidate();
       // Persist the primary agent pubkey so future cross-version imports can find it.
       // This also covers existing users upgrading from a build without this feature.
       const postLaunchApps = await HOLOCHAIN_MANAGER!.adminWebsocket.listApps({});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1203,7 +1203,7 @@ if (!RUNNING_WITH_COMMAND) {
         }
         // Kill holochain and lair
         if (LAIR_HANDLE) LAIR_HANDLE.kill();
-        if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.processHandle.kill();
+        if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.shutdown();
         // Remove all data
         await WE_FILE_SYSTEM.factoryReset();
         // restart Moss
@@ -1246,7 +1246,7 @@ if (!RUNNING_WITH_COMMAND) {
           window.window.close();
         }
         if (LAIR_HANDLE) LAIR_HANDLE.kill();
-        if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.processHandle.kill();
+        if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.shutdown();
         const options: Electron.RelaunchOptions = { args: process.argv };
         if (process.env.APPIMAGE) {
           options.args!.unshift('--appimage-extract-and-run');
@@ -1265,7 +1265,7 @@ if (!RUNNING_WITH_COMMAND) {
         window.window.close();
       }
       if (LAIR_HANDLE) LAIR_HANDLE.kill();
-      if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.processHandle.kill();
+      if (HOLOCHAIN_MANAGER) HOLOCHAIN_MANAGER.shutdown();
       const options: Electron.RelaunchOptions = { args: process.argv };
       if (process.env.APPIMAGE) {
         options.args!.unshift('--appimage-extract-and-run');
@@ -3160,7 +3160,7 @@ if (!RUNNING_WITH_COMMAND) {
       LAIR_HANDLE.kill();
     }
     if (HOLOCHAIN_MANAGER) {
-      HOLOCHAIN_MANAGER.processHandle.kill();
+      HOLOCHAIN_MANAGER.shutdown();
     }
     if (LOCAL_SERVICES_HANDLE) {
       LOCAL_SERVICES_HANDLE.kill();

--- a/src/main/ipc-contract-drift.test.ts
+++ b/src/main/ipc-contract-drift.test.ts
@@ -7,11 +7,10 @@ import path from 'node:path';
  *
  * The renderer↔main IPC surface is maintained by hand in two places: the preload
  * bridges (`ipcRenderer.invoke('channel', ...)`) and the main handlers
- * (`ipcMain.handle('channel', ...)`). Nothing links them, and they had already
- * drifted — five preload channels had no handler and rejected at runtime with
- * "No handler registered". This test makes that drift a failing build in either
- * direction:
- *   - every channel a preload bridge invokes must have a main handler, and
+ * (`ipcMain.handle('channel', ...)`), with nothing linking them. This test makes
+ * a mismatch a failing build in either direction:
+ *   - every channel a preload bridge invokes must have a main handler (a missing
+ *     one rejects at runtime with "No handler registered"), and
  *   - every main handler must be reachable from a preload bridge.
  *
  * Both are literal-string scans; a channel built from a variable would be
@@ -41,10 +40,7 @@ function channels(files: string[], callPattern: RegExp): Set<string> {
   return found;
 }
 
-const invoked = channels(
-  tsFiles(PRELOAD_DIR),
-  /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g,
-);
+const invoked = channels(tsFiles(PRELOAD_DIR), /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g);
 const handled = channels(tsFiles(MAIN_DIR), /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g);
 
 describe('IPC contract (preload ↔ main)', () => {
@@ -55,9 +51,10 @@ describe('IPC contract (preload ↔ main)', () => {
 
   it('every main handler is reachable from a preload bridge', () => {
     const orphans = [...handled].filter((c) => !invoked.has(c)).sort();
-    expect(orphans, `ipcMain.handle channels never invoked from preload: ${orphans.join(', ')}`).toEqual(
-      [],
-    );
+    expect(
+      orphans,
+      `ipcMain.handle channels never invoked from preload: ${orphans.join(', ')}`,
+    ).toEqual([]);
   });
 
   it('found a plausible number of channels (guards against the scan silently matching nothing)', () => {

--- a/src/main/ipc-contract-drift.test.ts
+++ b/src/main/ipc-contract-drift.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * IPC contract drift guard.
@@ -17,9 +18,11 @@ import path from 'node:path';
  * invisible here — keep channel names as string literals at the call site.
  */
 
-const REPO_ROOT = process.cwd();
-const PRELOAD_DIR = path.join(REPO_ROOT, 'src', 'preload');
-const MAIN_DIR = path.join(REPO_ROOT, 'src', 'main');
+// Resolve relative to this file (src/main/…), not the cwd, so the scan works
+// regardless of where vitest is invoked from.
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PRELOAD_DIR = path.join(SRC_DIR, 'preload');
+const MAIN_DIR = path.join(SRC_DIR, 'main');
 
 function tsFiles(dir: string): string[] {
   const out: string[] = [];

--- a/src/main/ipc-contract-drift.test.ts
+++ b/src/main/ipc-contract-drift.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * IPC contract drift guard.
+ *
+ * The renderer↔main IPC surface is maintained by hand in two places: the preload
+ * bridges (`ipcRenderer.invoke('channel', ...)`) and the main handlers
+ * (`ipcMain.handle('channel', ...)`). Nothing links them, and they had already
+ * drifted — five preload channels had no handler and rejected at runtime with
+ * "No handler registered". This test makes that drift a failing build in either
+ * direction:
+ *   - every channel a preload bridge invokes must have a main handler, and
+ *   - every main handler must be reachable from a preload bridge.
+ *
+ * Both are literal-string scans; a channel built from a variable would be
+ * invisible here — keep channel names as string literals at the call site.
+ */
+
+const REPO_ROOT = process.cwd();
+const PRELOAD_DIR = path.join(REPO_ROOT, 'src', 'preload');
+const MAIN_DIR = path.join(REPO_ROOT, 'src', 'main');
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFiles(p));
+    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(p);
+  }
+  return out;
+}
+
+function channels(files: string[], callPattern: RegExp): Set<string> {
+  const found = new Set<string>();
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8');
+    for (const m of src.matchAll(callPattern)) found.add(m[1]);
+  }
+  return found;
+}
+
+const invoked = channels(
+  tsFiles(PRELOAD_DIR),
+  /ipcRenderer\.invoke\(\s*['"]([^'"]+)['"]/g,
+);
+const handled = channels(tsFiles(MAIN_DIR), /ipcMain\.handle\(\s*['"]([^'"]+)['"]/g);
+
+describe('IPC contract (preload ↔ main)', () => {
+  it('every preload-invoked channel has a main handler', () => {
+    const dead = [...invoked].filter((c) => !handled.has(c)).sort();
+    expect(dead, `preload channels with no ipcMain.handle: ${dead.join(', ')}`).toEqual([]);
+  });
+
+  it('every main handler is reachable from a preload bridge', () => {
+    const orphans = [...handled].filter((c) => !invoked.has(c)).sort();
+    expect(orphans, `ipcMain.handle channels never invoked from preload: ${orphans.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('found a plausible number of channels (guards against the scan silently matching nothing)', () => {
+    expect(invoked.size).toBeGreaterThan(50);
+    expect(handled.size).toBeGreaterThan(50);
+  });
+});

--- a/src/main/launch.ts
+++ b/src/main/launch.ts
@@ -103,6 +103,9 @@ export async function launch(
       runOptions.holochainWasmLog,
     );
   } catch (e) {
+    // lair is already running at this point; kill it so a failed launch (and each
+    // splash-screen retry) doesn't leave an orphan lair against the keystore dir.
+    lairHandle.kill();
     weEmitter.emitMossError(`Failed to launch HolochainManager: ${e}`);
     throw new Error(`Failed to launch HolochainManager: ${e}`);
   }
@@ -114,6 +117,10 @@ export async function launch(
   try {
     weRustHandler = await rustUtils.WeRustHandler.connect(lairUrl, password);
   } catch (e) {
+    // Both lair and the conductor are running now; kill both so a failed launch
+    // doesn't leave them orphaned holding the keystore and the admin port.
+    lairHandle.kill();
+    holochainManager.shutdown();
     weEmitter.emitMossError(`Failed to connect to WeRustHandler: ${e}`);
     throw new Error(`Failed to connect to WeRustHandler: ${e}`);
   }

--- a/src/main/launch.ts
+++ b/src/main/launch.ts
@@ -142,103 +142,115 @@ export async function launch(
 
   //   console.log('Tools Library installed.');
   // }
-  // Install other default apps if necessary (not in applet-dev mode)
-  if (!runOptions.devInfo) {
-    await Promise.all(
-      Object.entries(DEFAULT_APPS).map(async ([appName, fileName]) => {
-        const appId = `default-app#${appName.toLowerCase()}`; // convert to lowercase to be able to use it in custom protocol
-        if (
-          !holochainManager.installedApps.map((appInfo) => appInfo.installed_app_id).includes(appId)
-        ) {
-          console.log(`Installing default app ${appName}`);
-          if (splashscreenWindow)
-            splashscreenWindow.webContents.send(
-              'loading-progress-update',
-              `Installing default app ${appName}...`,
-            );
-
-          const distributionInfo: DistributionInfo = {
-            type: 'default-app',
-          };
-          await holochainManager.installWebApp(
-            path.join(DEFAULT_APPS_DIRECTORY, fileName),
-            appId,
-            distributionInfo,
-            runOptions.appstoreNetworkSeed,
-          );
-          console.log(`Default app ${appName} installed.`);
-        } else {
-          // Compare the hashes to check whether happ and/or UI got an update
-          const currentAppAssetsInfo = mossFileSystem.readAppAssetsInfo(appId);
+  // Install other default apps if necessary (not in applet-dev mode). Wrapped so
+  // a failure in any post-spawn stage tears down the lair + conductor already
+  // running instead of throwing past the launch IPC's destructuring and leaving
+  // them orphaned holding the keystore and admin port.
+  try {
+    if (!runOptions.devInfo) {
+      await Promise.all(
+        Object.entries(DEFAULT_APPS).map(async ([appName, fileName]) => {
+          const appId = `default-app#${appName.toLowerCase()}`; // convert to lowercase to be able to use it in custom protocol
           if (
-            currentAppAssetsInfo.type === 'webhapp' &&
-            currentAppAssetsInfo.ui.location.type === 'filesystem'
+            !holochainManager.installedApps
+              .map((appInfo) => appInfo.installed_app_id)
+              .includes(appId)
           ) {
-            const webHappPath = path.join(DEFAULT_APPS_DIRECTORY, fileName);
-            const webHappBytes = fs.readFileSync(webHappPath);
-            const { happSha256, webhappSha256, uiSha256 } = await rustUtils.validateHappOrWebhapp(
-              Array.from(webHappBytes),
+            console.log(`Installing default app ${appName}`);
+            if (splashscreenWindow)
+              splashscreenWindow.webContents.send(
+                'loading-progress-update',
+                `Installing default app ${appName}...`,
+              );
+
+            const distributionInfo: DistributionInfo = {
+              type: 'default-app',
+            };
+            await holochainManager.installWebApp(
+              path.join(DEFAULT_APPS_DIRECTORY, fileName),
+              appId,
+              distributionInfo,
+              runOptions.appstoreNetworkSeed,
             );
-            console.log('READ uiHash: ', uiSha256);
-            if (happSha256 !== currentAppAssetsInfo.happ.sha256) {
-              // In case that the previous happ sha256 is not the one of KanDo 0.9.1, replace it fully
-              // const sha256Happ_0_9_1 =
-              //   'e0b9ce4f16b632b436b888373981e1023762b59cc3cc646d76aed36bb7b565ed';
-              // if (currentAppAssetsInfo.happ.sha256 !== sha256Happ_0_9_1) {
-              // console.warn(
-              //   'Found old KanDo feedback board. Uninstalling it and replacing it with a new version',
-              // );
-              // console.log(
-              //   `Old happ hash: ${currentAppAssetsInfo.happ.sha256}. New happ hash: ${happHash}`,
-              // );
-              // if (splashscreenWindow)
-              //   splashscreenWindow.webContents.send(
-              //     'loading-progress-update',
-              //     'Replacing feedback board with new version...',
-              //   );
-              // await holochainManager.adminWebsocket.uninstallApp({ installed_app_id: appId });
-              // // back up previous assets info
-              // mossFileSystem.backupAppAssetsInfo(appId);
-              // const networkSeed = defaultAppNetworkSeed();
-              // const distributionInfo: DistributionInfo = {
-              //   type: 'default-app',
-              // };
-              // // Install new app
-              // await holochainManager.installWebApp(
-              //   path.join(DEFAULT_APPS_DIRECTORY, fileName),
-              //   appId,
-              //   distributionInfo,
-              //   networkSeed,
-              // );
-              // return;
-              // } else {
-              console.warn(
-                'Got new default app with the same name but a different happ hash. Aborted UI update process.',
+            console.log(`Default app ${appName} installed.`);
+          } else {
+            // Compare the hashes to check whether happ and/or UI got an update
+            const currentAppAssetsInfo = mossFileSystem.readAppAssetsInfo(appId);
+            if (
+              currentAppAssetsInfo.type === 'webhapp' &&
+              currentAppAssetsInfo.ui.location.type === 'filesystem'
+            ) {
+              const webHappPath = path.join(DEFAULT_APPS_DIRECTORY, fileName);
+              const webHappBytes = fs.readFileSync(webHappPath);
+              const { happSha256, webhappSha256, uiSha256 } = await rustUtils.validateHappOrWebhapp(
+                Array.from(webHappBytes),
               );
-              return;
-              // }
-            }
-            if (uiSha256 && uiSha256 !== currentAppAssetsInfo.ui.location.sha256) {
-              // TODO emit this to the logs
-              console.log(`Found new UI for default app '${appId}'. Installing.`);
-              const newAppAssetsInfo = currentAppAssetsInfo;
-              newAppAssetsInfo.sha256 = webhappSha256;
-              (newAppAssetsInfo.ui.location as { type: 'filesystem'; sha256: string }).sha256 =
-                uiSha256;
-              await rustUtils.saveHappOrWebhapp(
-                webHappPath,
-                mossFileSystem.happsDir,
-                mossFileSystem.uisDir,
-              );
-              mossFileSystem.backupAppAssetsInfo(appId);
-              mossFileSystem.storeAppAssetsInfo(appId, newAppAssetsInfo);
+              console.log('READ uiHash: ', uiSha256);
+              if (happSha256 !== currentAppAssetsInfo.happ.sha256) {
+                // In case that the previous happ sha256 is not the one of KanDo 0.9.1, replace it fully
+                // const sha256Happ_0_9_1 =
+                //   'e0b9ce4f16b632b436b888373981e1023762b59cc3cc646d76aed36bb7b565ed';
+                // if (currentAppAssetsInfo.happ.sha256 !== sha256Happ_0_9_1) {
+                // console.warn(
+                //   'Found old KanDo feedback board. Uninstalling it and replacing it with a new version',
+                // );
+                // console.log(
+                //   `Old happ hash: ${currentAppAssetsInfo.happ.sha256}. New happ hash: ${happHash}`,
+                // );
+                // if (splashscreenWindow)
+                //   splashscreenWindow.webContents.send(
+                //     'loading-progress-update',
+                //     'Replacing feedback board with new version...',
+                //   );
+                // await holochainManager.adminWebsocket.uninstallApp({ installed_app_id: appId });
+                // // back up previous assets info
+                // mossFileSystem.backupAppAssetsInfo(appId);
+                // const networkSeed = defaultAppNetworkSeed();
+                // const distributionInfo: DistributionInfo = {
+                //   type: 'default-app',
+                // };
+                // // Install new app
+                // await holochainManager.installWebApp(
+                //   path.join(DEFAULT_APPS_DIRECTORY, fileName),
+                //   appId,
+                //   distributionInfo,
+                //   networkSeed,
+                // );
+                // return;
+                // } else {
+                console.warn(
+                  'Got new default app with the same name but a different happ hash. Aborted UI update process.',
+                );
+                return;
+                // }
+              }
+              if (uiSha256 && uiSha256 !== currentAppAssetsInfo.ui.location.sha256) {
+                // TODO emit this to the logs
+                console.log(`Found new UI for default app '${appId}'. Installing.`);
+                const newAppAssetsInfo = currentAppAssetsInfo;
+                newAppAssetsInfo.sha256 = webhappSha256;
+                (newAppAssetsInfo.ui.location as { type: 'filesystem'; sha256: string }).sha256 =
+                  uiSha256;
+                await rustUtils.saveHappOrWebhapp(
+                  webHappPath,
+                  mossFileSystem.happsDir,
+                  mossFileSystem.uisDir,
+                );
+                mossFileSystem.backupAppAssetsInfo(appId);
+                mossFileSystem.storeAppAssetsInfo(appId, newAppAssetsInfo);
+              }
             }
           }
-        }
-      }),
-    );
-  } else {
-    await devSetup(runOptions.devInfo, holochainManager, mossFileSystem, false, weRustHandler);
+        }),
+      );
+    } else {
+      await devSetup(runOptions.devInfo, holochainManager, mossFileSystem, false, weRustHandler);
+    }
+  } catch (e) {
+    lairHandle.kill();
+    holochainManager.shutdown();
+    weEmitter.emitMossError(`Failed during post-launch setup: ${e}`);
+    throw new Error(`Failed during post-launch setup: ${e}`);
   }
   return [lairHandle, holochainManager, weRustHandler];
 }

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -2,7 +2,6 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 // IPC_CHANGE_HERE
 import {
-  ActionHashB64,
   AgentPubKeyB64,
   CallZomeRequest,
   DnaHashB64,
@@ -83,8 +82,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   requestIframeStoreSync: () => ipcRenderer.invoke('request-iframe-store-sync'),
   removeWillNavigateListeners: () => ipcRenderer.removeAllListeners('will-navigate-external'),
   closeMainWindow: () => ipcRenderer.invoke('close-main-window'),
-  openApp: (appId: string) => ipcRenderer.invoke('open-app', appId),
-  openAppStore: () => ipcRenderer.invoke('open-appstore'),
   openWalWindow: (iframeSrc: string, appletId: AppletId, groupId: DnaHashB64, wal: WAL) => {
     ipcRenderer.invoke('open-wal-window', iframeSrc, appletId, groupId, wal);
   },
@@ -152,10 +149,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       weaveLocation,
       appletName,
     ),
-  enableDevMode: () => ipcRenderer.invoke('enable-dev-mode'),
-  disableDevMode: () => ipcRenderer.invoke('disable-dev-mode'),
-  fetchIcon: (appActionHashB64: ActionHashB64) =>
-    ipcRenderer.invoke('fetch-icon', appActionHashB64),
   selectScreenOrWindow: () => ipcRenderer.invoke('select-screen-or-window'),
   captureScreen: () => ipcRenderer.invoke('capture-screen'),
   getFeedbackWorkerUrl: () => ipcRenderer.invoke('get-feedback-worker-url'),

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -1056,9 +1056,9 @@ export async function handleAppletIframeMessage(
     case 'ready':
     case 'search':
       // Declared in AppletToParentRequest but not sent by any current applet, so
-      // the host has never handled them (they fell through to the throw below).
-      // Kept as explicit cases so the exhaustiveness guard holds; wire a real
-      // handler here if an applet starts sending one.
+      // the host has no handler for them. Kept as explicit cases so the
+      // exhaustiveness guard holds; wire a real handler here if an applet starts
+      // sending one.
       throw Error(`Got unsupported message type: '${message.type}'`);
     default:
       // Exhaustiveness guard: every AppletToParentRequest variant must have a

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -151,7 +151,7 @@ export function buildHeadlessWeaveClient(mossStore: MossStore): WeaveServices {
     // why: cast lets us add `isAppletInstalled` here without bloating the
     // public AssetServices type in @theweave/api. `<wal-embed>` reaches it
     // via optional chaining on `window.__WEAVE_API__.assets`.
-    assets: ({
+    assets: {
       assetInfo: async (wal: WAL): Promise<AssetLocationAndInfo | undefined> => {
         const maybeCachedInfo = mossStore.mossCache.assetInfo.value(wal);
         if (maybeCachedInfo) {
@@ -262,7 +262,7 @@ export function buildHeadlessWeaveClient(mossStore: MossStore): WeaveServices {
       assetStore: (_wal: WAL) => {
         throw new Error('assetStore is not supported in headless WeaveServices.');
       },
-    } as any),
+    } as any,
     async requestClose() {
       throw new Error('Close request is not supported in the headless WeaveClient.');
     },
@@ -1062,9 +1062,8 @@ export async function handleAppletIframeMessage(
       throw Error(`Got unsupported message type: '${message.type}'`);
     default:
       // Exhaustiveness guard: every AppletToParentRequest variant must have a
-      // case above. A new variant makes `message` non-`never` here, which is a
-      // compile error — surfacing the gap at build time rather than as a runtime
-      // "unsupported message type" reject.
+      // case above, so a new variant makes `message` non-`never` here and fails
+      // the build.
       return assertNever(message);
   }
 }

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -1053,9 +1053,24 @@ export async function handleAppletIframeMessage(
       groupStore.unsubscribeFromAssetStore(message.wal, encodeHashToBase64(source.appletHash));
       return;
     }
-    default:
+    case 'ready':
+    case 'search':
+      // Declared in AppletToParentRequest but not sent by any current applet, so
+      // the host has never handled them (they fell through to the throw below).
+      // Kept as explicit cases so the exhaustiveness guard holds; wire a real
+      // handler here if an applet starts sending one.
       throw Error(`Got unsupported message type: '${message.type}'`);
+    default:
+      // Exhaustiveness guard: every AppletToParentRequest variant must have a
+      // case above. A new variant makes `message` non-`never` here, which is a
+      // compile error — surfacing the gap at build time rather than as a runtime
+      // "unsupported message type" reject.
+      return assertNever(message);
   }
+}
+
+function assertNever(message: never): never {
+  throw Error(`Got unsupported message type: '${(message as AppletToParentRequest).type}'`);
 }
 
 export class AppletHost {

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -2,7 +2,6 @@ import {
   AppInfo,
   CallZomeRequest,
   CallZomeRequestSigned,
-  ActionHashB64,
   AgentPubKeyB64,
   InstalledAppId,
   ZomeName,
@@ -122,7 +121,6 @@ declare global {
         ) => any,
       ) => void;
       closeMainWindow: () => Promise<void>;
-      openApp: (appId: string) => Promise<void>;
       openWalWindow: (
         iframeSrc: string,
         appletId: AppletId,
@@ -176,9 +174,6 @@ declare global {
         weaveLocation: WeaveLocation | undefined,
         appletName: string | undefined,
       ) => Promise<void>;
-      enableDevMode: () => Promise<void>;
-      disableDevMode: () => Promise<void>;
-      fetchIcon: (appActionHashB64: ActionHashB64) => Promise<string>;
       selectScreenOrWindow: () => Promise<string>;
       captureScreen: () => Promise<string>;
       getFeedbackWorkerUrl: () => Promise<string>;
@@ -391,10 +386,6 @@ export async function getToolIcon(
   return window.electronAPI.getToolIcon(toolId, resourceLocation);
 }
 
-export async function openApp(appId: string): Promise<void> {
-  return window.electronAPI.openApp(appId);
-}
-
 export async function isDevModeEnabled(): Promise<boolean> {
   return window.electronAPI.isDevModeEnabled();
 }
@@ -407,13 +398,6 @@ export async function appletDevConfig(): Promise<WeaveDevConfig | undefined> {
   return window.electronAPI.appletDevConfig();
 }
 
-export async function enableDevMode(): Promise<void> {
-  return window.electronAPI.enableDevMode();
-}
-
-export async function disableDevMode(): Promise<void> {
-  return window.electronAPI.disableDevMode();
-}
 
 export async function selectScreenOrWindow(): Promise<string> {
   return window.electronAPI.selectScreenOrWindow();

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -398,7 +398,6 @@ export async function appletDevConfig(): Promise<WeaveDevConfig | undefined> {
   return window.electronAPI.appletDevConfig();
 }
 
-
 export async function selectScreenOrWindow(): Promise<string> {
   return window.electronAPI.selectScreenOrWindow();
 }
@@ -411,10 +410,7 @@ export async function validateHappOrWebhapp(bytes: number[]) {
   return window.electronAPI.validateHappOrWebhapp(bytes);
 }
 
-export const signZomeCallApplet = async (
-  request: CallZomeRequest,
-  callerAppletIds: string[],
-) => {
+export const signZomeCallApplet = async (request: CallZomeRequest, callerAppletIds: string[]) => {
   return window.electronAPI.signZomeCallApplet(request, callerAppletIds);
 };
 

--- a/src/renderer/src/validationSchemas.ts
+++ b/src/renderer/src/validationSchemas.ts
@@ -413,13 +413,6 @@ export const AppletToParentRequest = Type.Union([
   ),
   Type.Object(
     {
-      type: Type.Literal('asset-to-pocket'),
-      wal: WAL,
-    },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
       type: Type.Literal('user-select-asset'),
       from: Type.Optional(
         Type.Union([
@@ -521,20 +514,13 @@ export const AppletToParentRequest = Type.Union([
     },
     { additionalProperties: false },
   ),
-  Type.Object(
-    {
-      type: Type.Literal('unsubscribe-from-asset-store'),
-      wal: WAL,
-    },
-    { additionalProperties: false },
-  ),
 ]);
 
 /**
  * Compile-time link between this TypeBox validator and the AppletToParentRequest
  * union in @theweave/api. The two are maintained by hand; if a new message type
  * is added to the union but not here (or vice versa), the message-type
- * discriminant sets diverge and `_WireContractInSync` fails to compile. This
+ * discriminant sets diverge and `WireContractInSync` fails to compile. This
  * catches the drift that would otherwise make a new message fail validateRequest
  * at runtime — the applet-side counterpart to the IPC-contract drift test.
  */
@@ -543,6 +529,4 @@ type UnionMessageTypes = AppletToParentRequestType['type'];
 type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 type Assert<T extends true> = T;
 // Exported only so tsc counts it as used; the compile-time check is the point.
-export type WireContractInSync = Assert<
-  MutuallyAssignable<SchemaMessageTypes, UnionMessageTypes>
->;
+export type WireContractInSync = Assert<MutuallyAssignable<SchemaMessageTypes, UnionMessageTypes>>;

--- a/src/renderer/src/validationSchemas.ts
+++ b/src/renderer/src/validationSchemas.ts
@@ -4,7 +4,8 @@
  * The corresponding typescript types are defined in libs/api/types.ts
  */
 
-import { Type } from '@sinclair/typebox';
+import { Type, type Static } from '@sinclair/typebox';
+import type { AppletToParentRequest as AppletToParentRequestType } from '@theweave/api';
 
 const EntryHash = Type.Uint8Array({ minByteLength: 39, maxByteLength: 39 });
 const ActionHash = Type.Uint8Array({ minByteLength: 39, maxByteLength: 39 });
@@ -528,3 +529,20 @@ export const AppletToParentRequest = Type.Union([
     { additionalProperties: false },
   ),
 ]);
+
+/**
+ * Compile-time link between this TypeBox validator and the AppletToParentRequest
+ * union in @theweave/api. The two are maintained by hand; if a new message type
+ * is added to the union but not here (or vice versa), the message-type
+ * discriminant sets diverge and `_WireContractInSync` fails to compile. This
+ * catches the drift that would otherwise make a new message fail validateRequest
+ * at runtime — the applet-side counterpart to the IPC-contract drift test.
+ */
+type SchemaMessageTypes = Static<typeof AppletToParentRequest>['type'];
+type UnionMessageTypes = AppletToParentRequestType['type'];
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type Assert<T extends true> = T;
+// Exported only so tsc counts it as used; the compile-time check is the point.
+export type WireContractInSync = Assert<
+  MutuallyAssignable<SchemaMessageTypes, UnionMessageTypes>
+>;

--- a/wdocker/src/const.ts
+++ b/wdocker/src/const.ts
@@ -10,20 +10,14 @@ const __dirname = path.dirname(__filename);
 // here since there is a check to prevent accidental use of a production bootstrap server in development
 // mode
 export const PRODUCTION_BOOTSTRAP_URLS = [
-  'https://bootstrap.moss.social',
+  'https://bootstrap-relay.moss.social',
   'https://dev-test-bootstrap2.holochain.org',
 ];
-// The first one will be picked by default. But all production signaling servers should be listed
-// here since there is a check to prevent accidental use of a production signaling server in development
-// mode
-export const PRODUCTION_SIGNALING_URLS = [
-  'wss://bootstrap.moss.social',
-  'wss://dev-test-bootstrap2.holochain.org',
-];
-
-// The first one will be picked by default.
+// The first one will be picked by default. Holochain 0.7 serves the iroh relay
+// from the same kitsune2-bootstrap-srv node as the bootstrap server; the
+// trailing-dot FQDN is the iroh relay URL convention.
 export const PRODUCTION_RELAY_URLS = [
-  'https://iroh-relay.moss.social./',
+  'https://bootstrap-relay.moss.social./',
   'https://use1-1.relay.n0.iroh-canary.iroh.link./',
 ];
 


### PR DESCRIPTION
Phase 1 of the maintainability plan (close the wire-contract drift; add the conductor crash-detection fix), plus the small follow-ups that had accrued. One concern per commit.

## Phase 1

- **Remove 5 dead IPC channels + drift test** (`9075b5c3`). `enable-dev-mode`, `disable-dev-mode`, `fetch-icon`, `open-app`, `open-appstore` were invoked in preload with no `ipcMain.handle` (rejecting at runtime); none had a caller. `src/main/ipc-contract-drift.test.ts` now fails the build if any preload channel lacks a handler or any handler is unreachable — the realized-bug class can't recur.
- **Exhaustive applet-host switch + TypeBox↔union link** (`2a4f1363`). The `handleAppletIframeMessage` default is now a `never` exhaustiveness guard (a new `AppletToParentRequest` variant without a case is a compile error; this surfaced two legacy variants `ready`/`search` that no applet sends). `validationSchemas.ts` links to the union so the validator's message-type discriminants must match `AppletToParentRequest` (`WireContractInSync`) — verified non-vacuous with a negative control. Two of the three hand-maintained copies of the applet contract now fail the build on drift.
- **Conductor/lair crash detection, F4** (`ae86546a`). The launch promise only settled on `'Conductor ready.'` or two literal error strings and nothing watched the process — a port race or incompatible DB left the UI hung at "starting Holochain..." forever. Added `error`/`exit` listeners + a generous (5 min) ready-timeout backstop, guarded by a single `settled` flag; a post-startup crash is surfaced via `emitHolochainFatalPanic` instead of dropped.

## Follow-ups

- **wdocker network defaults + signal cleanup** (`68459818`) — the second step from #232: point wdocker's bootstrap/relay defaults at `bootstrap-relay.moss.social`, remove the unused `PRODUCTION_SIGNALING_URLS`.
- **Extract `AppletZomeCallAuthorizer` + invalidate on uninstall** (`d08cde5d`) — deferred #231 review findings 5 & 6: move ~95 lines of signing cache/authorization out of the 3,200-line `index.ts` into a unit-tested module, and clear its cache on uninstall so it never keeps granting for a gone app.

## Verification

- `yarn typecheck` + `yarn test:unit` (138) green.
- e2e `#12` passes — launches a real conductor (F4 happy path) and round-trips an applet zome call through the extracted signer.

## Not included (noted follow-ups)
- The full 78-handler typed IPC contract (the drift *test* covers the realized risk at much lower cost; a full contract-typed registration is a larger refactor for later).
- F4's non-re-entrant launch handler (orphans a conductor on double-launch) and quit ordering (lair before conductor).