### PR TITLE
fix(e2e): disambiguate invite-dialog copy-link locator (fixes smoke #03)

### DIFF
--- a/tests/e2e/helpers/groups.ts
+++ b/tests/e2e/helpers/groups.ts
@@ -236,9 +236,12 @@ export async function getCurrentGroupInviteLink(page: Page): Promise<string> {
   // ("Node is not an <input>"). Read its `.value` JS property via evaluate.
   // Poll because the template binds `.value=...` reactively — first render
   // frame may have an empty value before invitationUrl resolves.
+  // The dialog now has two copy-link inputs — the invite link and, below it, the
+  // invite code. Take the first (the link); the /invite/ poll below confirms it.
   const readLink = () =>
     page
       .locator('invite-people-dialog sl-input.copy-link-input')
+      .first()
       .evaluate((el) => (el as HTMLElement & { value: string }).value);
   await expect.poll(readLink, { timeout: 10_000 }).toMatch(/invite/i);
   const link = await readLink();

--- a/tests/e2e/helpers/groups.ts
+++ b/tests/e2e/helpers/groups.ts
@@ -236,13 +236,17 @@ export async function getCurrentGroupInviteLink(page: Page): Promise<string> {
   // ("Node is not an <input>"). Read its `.value` JS property via evaluate.
   // Poll because the template binds `.value=...` reactively — first render
   // frame may have an empty value before invitationUrl resolves.
-  // The dialog now has two copy-link inputs — the invite link and, below it, the
+  // The dialog has two copy-link inputs — the invite link and, below it, the
   // invite code. Take the first (the link); the /invite/ poll below confirms it.
+  // A short evaluate timeout keeps a never-opening dialog (zero matches) failing
+  // fast with a locator error rather than hanging to the suite timeout.
   const readLink = () =>
     page
       .locator('invite-people-dialog sl-input.copy-link-input')
       .first()
-      .evaluate((el) => (el as HTMLElement & { value: string }).value);
+      .evaluate((el) => (el as HTMLElement & { value: string }).value, undefined, {
+        timeout: 5000,
+      });
   await expect.poll(readLink, { timeout: 10_000 }).toMatch(/invite/i);
   const link = await readLink();
 


### PR DESCRIPTION
Smoke #03 (join-group) has been red on main-0.7 since the invite-code feature landed: the invite dialog now renders **two** `.copy-link-input` elements — the invite link and, below it, the invite code — so `getCurrentGroupInviteLink`'s locator matched two elements and failed Playwright strict mode (`strict mode violation: ... resolved to 2 elements`).

Fix: take `.first()` (the link). The helper's existing `expect.poll(readLink).toMatch(/invite/i)` already confirms it's the link, not the code.

This is independent of the Phase 1 PR (#233) — that PR inherits the same red because it branched off main-0.7; merging this un-reds the smoke suite for both.