### PR TITLE
chore: bump profiles to v0.701.0 and group happ to 0.16.0-dev.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5815,7 +5815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5828,7 +5828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,8 +2395,8 @@ dependencies = [
 
 [[package]]
 name = "hc_zome_profiles_coordinator"
-version = "0.5.0"
-source = "git+https://github.com/holochain-open-dev/profiles?tag=v0.700.0#2d423491463b71bae3c97a506cced95d50d219ea"
+version = "0.6.0"
+source = "git+https://github.com/holochain-open-dev/profiles?tag=v0.701.0#7e11bd7e9380dce4583cc152115044ffa660fd19"
 dependencies = [
  "derive_more 0.99.20",
  "hc_zome_profiles_integrity",
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "hc_zome_profiles_integrity"
 version = "0.5.0"
-source = "git+https://github.com/holochain-open-dev/profiles?tag=v0.700.0#2d423491463b71bae3c97a506cced95d50d219ea"
+source = "git+https://github.com/holochain-open-dev/profiles?tag=v0.701.0#7e11bd7e9380dce4583cc152115044ffa660fd19"
 dependencies = [
  "derive_more 0.99.20",
  "hdi",
@@ -5815,7 +5815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5828,7 +5828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theweave/cli",
-  "version": "0.16.0-dev.3",
+  "version": "0.16.0-dev.4",
   "description": "CLI to run Tools for the Weave in development mode",
   "license": "CAL-1.0",
   "repository": {
@@ -24,7 +24,7 @@
     "@electron-toolkit/preload": "^2.0.0",
     "@electron-toolkit/utils": "^2.0.0",
     "electron-updater": "6.6.2",
-    "@theweave/api": "^0.7.0-dev.1",
+    "@theweave/api": "^0.7.0-dev.2",
     "@theweave/moss-types": "0.7.0-dev.1",
     "@theweave/utils": "0.7.0-dev.1",
     "@msgpack/msgpack": "^2.8.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@holochain/client": "^0.21.0",
     "@holochain-open-dev/elements": "^0.700.0",
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@lightningrodlabs/we-rust-utils": "^0.700.0-dev.0",

--- a/dnas/group/zomes/coordinator/profiles/Cargo.toml
+++ b/dnas/group/zomes/coordinator/profiles/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib", "rlib"]
 name = "profiles_coordinator"
 
 [dependencies]
-hc_zome_profiles_coordinator = { git = "https://github.com/holochain-open-dev/profiles", tag = "v0.700.0" }
+hc_zome_profiles_coordinator = { git = "https://github.com/holochain-open-dev/profiles", tag = "v0.701.0" }

--- a/dnas/group/zomes/integrity/profiles/Cargo.toml
+++ b/dnas/group/zomes/integrity/profiles/Cargo.toml
@@ -10,4 +10,4 @@ name = "profiles_integrity"
 [dependencies]
 serde = "1"
 derive_more = "0"
-hc_zome_profiles_integrity = { git = "https://github.com/holochain-open-dev/profiles", tag = "v0.700.0" }
+hc_zome_profiles_integrity = { git = "https://github.com/holochain-open-dev/profiles", tag = "v0.701.0" }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         exclude: [
           '@holochain/client',
           '@holochain-open-dev/utils',
+          '@holochain-open-dev/profiles',
           'nanoid',
           'mime',
           '@theweave/moss-types',

--- a/example/ui/package.json
+++ b/example/ui/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@holochain-open-dev/elements": "^0.700.0",
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@holochain/client": "^0.21.0",

--- a/iframes/applet-iframe/package.json
+++ b/iframes/applet-iframe/package.json
@@ -5,7 +5,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain/client": "^0.21.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theweave/api",
-  "version": "0.7.0-dev.1",
+  "version": "0.7.0-dev.2",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "license": "MIT",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -26,7 +26,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain/client": "^0.21.0",
     "@msgpack/msgpack": "^2.8.0",
     "js-base64": "^3.7.2"

--- a/libs/elements/package.json
+++ b/libs/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theweave/elements",
-  "version": "0.7.0-dev.1",
+  "version": "0.7.0-dev.2",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
-    "@theweave/api": "^0.7.0-dev.0",
+    "@theweave/api": "^0.7.0-dev.2",
     "@lit/context": "^1.0.1",
     "@lit/localize": "^0.12.0",
     "@mdi/js": "^7.2.0",

--- a/libs/elements/package.json
+++ b/libs/elements/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@holochain/client": "^0.21.0",
     "@holochain-open-dev/elements": "^0.700.0",
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@theweave/api": "^0.7.0-dev.0",

--- a/moss.config.json
+++ b/moss.config.json
@@ -1,8 +1,8 @@
 {
   "holochain": "0.7.0",
   "groupHapp": {
-    "version": "0.16.0-dev.2",
-    "sha256": "603ef404712c2ef6293397380f61bdd24796c471f408c9732df87425be8df087"
+    "version": "0.16.0-dev.3",
+    "sha256": "643563f7485bc8c208f170e718acf613d424f2d122a5fd7a3e671a4018725ce1"
   },
   "binariesAppendix": "moss-0.16",
   "feedbackWorkerUrl": "https://moss-design-feedback.eric-114.workers.dev"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@electron-toolkit/preload": "^2.0.0",
     "@electron-toolkit/utils": "^2.0.0",
     "@holochain-open-dev/elements": "^0.700.0",
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@holochain/client": "^0.21.0",

--- a/src/main/cli/devSetup.ts
+++ b/src/main/cli/devSetup.ts
@@ -37,6 +37,7 @@ import * as childProcess from 'child_process';
 import split from 'split';
 import { AgentProfile, AppletConfig, GroupConfig, WebHappLocation } from '@theweave/moss-types';
 import { EntryRecord } from '@holochain-open-dev/utils';
+import { ProfilesClient } from '@holochain-open-dev/profiles/dist/profiles-client.js';
 import { KITSUNE2_BOOTSTRAP_SRV_BINARY } from '../const';
 import {
   appIdFromAppletHash,
@@ -494,14 +495,10 @@ async function joinGroup(
   const avatarSrc = agentProfile.avatar ? await readIcon(agentProfile.avatar) : undefined;
   console.log('Creating profile....');
 
-  await groupWebsocket.callZome({
-    role_name: 'group',
-    zome_name: 'profiles',
-    fn_name: 'create_profile',
-    payload: {
-      nickname: agentProfile.nickname,
-      fields: avatarSrc ? { avatar: avatarSrc } : {},
-    },
+  const profilesClient = new ProfilesClient(groupWebsocket, 'group');
+  await profilesClient.createProfile({
+    nickname: agentProfile.nickname,
+    fields: avatarSrc ? { avatar: avatarSrc } : {},
   });
   console.log('profile created.');
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,6 +123,7 @@ import {
 import { decideZomeCallSignable, type ZomeCallSigningDecision } from './zomeCallSigningPolicy';
 import { sortVersionsDescending } from './utils';
 import { Profile as AgentProfile } from '@holochain-open-dev/profiles';
+import { ProfilesClient } from '@holochain-open-dev/profiles/dist/profiles-client.js';
 import { Jimp } from 'jimp';
 
 const rustUtils = require('@lightningrodlabs/we-rust-utils');
@@ -2215,14 +2216,10 @@ if (!RUNNING_WITH_COMMAND) {
                   : {};
 
               emitProgress(current, groupProfile?.name, 'setting-profile');
-              await appWs.callZome({
-                role_name: 'group',
-                zome_name: 'profiles',
-                fn_name: 'create_profile',
-                payload: {
-                  nickname: agentProfile.nickname,
-                  fields: normalizedAgentFields,
-                },
+              const profilesClient = new ProfilesClient(appWs, 'group');
+              await profilesClient.createProfile({
+                nickname: agentProfile.nickname,
+                fields: normalizedAgentFields,
               });
             } catch (profileErr) {
               console.warn(`Failed to set agent profile for group ${appId}:`, profileErr);

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -11,7 +11,7 @@
     "@fontsource-variable/inter": "^5.2.5",
     "@holochain/client": "^0.21.0",
     "@holochain-open-dev/elements": "^0.700.0",
-    "@holochain-open-dev/profiles": "^0.700.0",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain-open-dev/stores": "^0.700.0",
     "@holochain-open-dev/utils": "^0.700.0",
     "@theweave/api": "^0.7.0-dev.0",

--- a/wdocker/package.json
+++ b/wdocker/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@folder/xdg": "4.0.1",
+    "@holochain-open-dev/profiles": "^0.701.0",
     "@holochain/client": "^0.21.0",
     "@lightningrodlabs/we-rust-utils": "^0.700.0-dev.0",
     "@theweave/api": "file:../libs/api",

--- a/wdocker/src/commands/conductor/join-group.ts
+++ b/wdocker/src/commands/conductor/join-group.ts
@@ -4,6 +4,7 @@ import {
   globalPubKeyFromListAppsResponse,
 } from '@theweave/utils';
 import { AdminWebsocket, AppInfo, encodeHashToBase64 } from '@holochain/client';
+import { ProfilesClient } from '@holochain-open-dev/profiles/dist/profiles-client.js';
 import { input } from '@inquirer/prompts';
 
 import {
@@ -50,15 +51,11 @@ export async function joinGroup(conductorId: string, inviteLink: string): Promis
   console.log('Creating profile');
   const weRustHandler = await getWeRustHandler(wDockerFs, password);
   const groupAppWs = await getAppWs(adminWs, appPort, appInfo.installed_app_id, weRustHandler);
-  await groupAppWs.callZome({
-    role_name: 'group',
-    zome_name: 'profiles',
-    fn_name: 'create_profile',
-    payload: {
-      nickname: profileName,
-      fields: {
-        wdockerNode: wdockerNodeDescription,
-      },
+  const profilesClient = new ProfilesClient(groupAppWs, 'group');
+  await profilesClient.createProfile({
+    nickname: profileName,
+    fields: {
+      wdockerNode: wdockerNodeDescription,
     },
   });
   console.log('Group joined successfully.');

--- a/wdocker/src/daemon/daemon.ts
+++ b/wdocker/src/daemon/daemon.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import { startConductor } from './start.js';
 import { WDockerFilesystem } from '../filesystem.js';
 import { getAdminWsAndAppPort, getAppWs, getWeRustHandler } from '../helpers/helpers.js';
+import { ProfilesClient } from '@holochain-open-dev/profiles/dist/profiles-client.js';
 import {
   ALWAYS_ONLINE_TAG,
   GroupClient,
@@ -140,32 +141,18 @@ setTimeout(async () => {
     const myPubkeySum = Array.from(groupAppWs.myPubKey).reduce((acc, curr) => acc + curr, 0);
 
     // Get all local agents first, then try getting them over the network
-    const allAgents: AgentPubKey[] = await groupAppWs.callZome({
-      role_name: 'group',
-      zome_name: 'profiles',
-      fn_name: 'get_agents_with_profile',
-      payload: { input: null, local: true },
-    });
+    const profilesClient = new ProfilesClient(groupAppWs, 'group');
+    const allAgents: AgentPubKey[] = await profilesClient.getAgentsWithProfile(true);
     GROUP_ALL_AGENTS[groupApp.installed_app_id] = allAgents;
     try {
-      const allAgents: AgentPubKey[] = await groupAppWs.callZome({
-        role_name: 'group',
-        zome_name: 'profiles',
-        fn_name: 'get_agents_with_profile',
-        payload: { input: null, local: false },
-      });
+      const allAgents: AgentPubKey[] = await profilesClient.getAgentsWithProfile(false);
       GROUP_ALL_AGENTS[groupApp.installed_app_id] = allAgents;
     } catch (e) {
       console.warn('WARN: Failed to get agents with profile via the network.');
     }
     setInterval(async () => {
       try {
-        const allAgents: AgentPubKey[] = await groupAppWs.callZome({
-          role_name: 'group',
-          zome_name: 'profiles',
-          fn_name: 'get_agents_with_profile',
-          payload: { input: null, local: false },
-        });
+        const allAgents: AgentPubKey[] = await profilesClient.getAgentsWithProfile(false);
         GROUP_ALL_AGENTS[groupApp.installed_app_id] = allAgents;
       } catch (e) {
         console.warn('WARN: Failed to get agents with profile via the network.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,7 +3115,7 @@
     defer-to-connect "^2.0.0"
 
 "@theweave/api@file:libs/api":
-  version "0.7.0-dev.1"
+  version "0.7.0-dev.2"
   dependencies:
     "@holochain-open-dev/profiles" "^0.701.0"
     "@holochain/client" "^0.21.0"
@@ -3123,7 +3123,7 @@
     js-base64 "^3.7.2"
 
 "@theweave/elements@file:libs/elements":
-  version "0.7.0-dev.1"
+  version "0.7.0-dev.2"
   dependencies:
     "@holochain-open-dev/elements" "^0.700.0"
     "@holochain-open-dev/profiles" "^0.701.0"
@@ -3134,7 +3134,7 @@
     "@lit/localize" "^0.12.0"
     "@mdi/js" "^7.2.0"
     "@shoelace-style/shoelace" "^2.20.0"
-    "@theweave/api" "^0.7.0-dev.0"
+    "@theweave/api" "^0.7.0-dev.2"
     js-base64 "^3.7.5"
     lit "^3.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,10 +1557,10 @@
     prosemirror-state "^1.4.3"
     prosemirror-view "^1.31.3"
 
-"@holochain-open-dev/profiles@^0.700.0":
-  version "0.700.0"
-  resolved "https://registry.yarnpkg.com/@holochain-open-dev/profiles/-/profiles-0.700.0.tgz#0d2503ae5d56f6475d7fe7c3f2ad887e1fda58a2"
-  integrity sha512-VKF0HiOdKvDUNRw8dqlFgXHjq8DrJN81CE2CUYgDTYYzvo8Jixc49I3OAgzVww0E3uIgn9XyNBYeI5UavBA/vw==
+"@holochain-open-dev/profiles@^0.701.0":
+  version "0.701.0"
+  resolved "https://registry.yarnpkg.com/@holochain-open-dev/profiles/-/profiles-0.701.0.tgz#d46d4bb076fe5c901d8b9a28d505e1aa4b68261b"
+  integrity sha512-AM+mWSd5l2Hv3XO7JcP/owe4F7Jvg4vwbCBvtLGe/S3zZlaIyrYvPu1c4gMWbvLW79PKD9NuoWnE9NGkyPqfaQ==
   dependencies:
     "@holochain-open-dev/elements" "^0.700.0"
     "@holochain-open-dev/stores" "^0.700.0"
@@ -3115,18 +3115,18 @@
     defer-to-connect "^2.0.0"
 
 "@theweave/api@file:libs/api":
-  version "0.7.0-dev.0"
+  version "0.7.0-dev.1"
   dependencies:
-    "@holochain-open-dev/profiles" "^0.700.0"
+    "@holochain-open-dev/profiles" "^0.701.0"
     "@holochain/client" "^0.21.0"
     "@msgpack/msgpack" "^2.8.0"
     js-base64 "^3.7.2"
 
 "@theweave/elements@file:libs/elements":
-  version "0.7.0-dev.0"
+  version "0.7.0-dev.1"
   dependencies:
     "@holochain-open-dev/elements" "^0.700.0"
-    "@holochain-open-dev/profiles" "^0.700.0"
+    "@holochain-open-dev/profiles" "^0.701.0"
     "@holochain-open-dev/stores" "^0.700.0"
     "@holochain-open-dev/utils" "^0.700.0"
     "@holochain/client" "^0.21.0"
@@ -3139,7 +3139,7 @@
     lit "^3.0.2"
 
 "@theweave/group-client@file:shared/group-client":
-  version "0.7.0-dev.0"
+  version "0.7.0-dev.1"
   dependencies:
     "@holochain-open-dev/utils" "^0.700.0"
     "@holochain/client" "^0.21.0"
@@ -3147,7 +3147,7 @@
     "@theweave/api" "^0.7.0-dev.0"
 
 "@theweave/utils@file:shared/utils":
-  version "0.7.0-dev.0"
+  version "0.7.0-dev.1"
   dependencies:
     "@holochain/client" "^0.21.0"
     "@msgpack/msgpack" "^2.7.2"


### PR DESCRIPTION
Pulls in the profiles fix (holochain-open-dev/profiles v0.701.0) where `create_profile`/`update_profile` no longer hit the network for the prefix-path ensure. HDI 0.8's `TypedPath` defaulted to `GetStrategy::Network`, so `path.ensure()` made a network `get_links` during profile creation — on a freshly joined group with the transport not yet registered on the relay this failed the whole zome call with:

```
Host("Connection attempted before home relay URL is known (src: None)")
```

Changes:
- `hc_zome_profiles_*` git deps → tag `v0.701.0` (coordinator crate 0.6.0)
- `@holochain-open-dev/profiles` → ^0.701.0 across workspaces
- group happ rebuilt: `moss.config.json` groupHapp 0.16.0-dev.3, sha256 `643563f7485bc8c208f170e718acf613d424f2d122a5fd7a3e671a4018725ce1`

Zome payloads for `create_profile`/`update_profile` are now `{ input: Profile, local?: bool }` (breaking, no 0.7 users yet). Moss call sites go through `ProfilesClient` and need no changes; the group DNA's profiles zomes re-export the crate wholesale.

Verified: zome wasm build, `hc app pack`, `yarn typecheck`, and the full group tryorama suite (11 tests).

Review follow-up (1507ee1a): three call sites hand-rolled `create_profile` payloads and would have broken against the new payload shape — dev-mode agent setup, group import/restore, and wdocker `join-group`. They now go through `ProfilesClient` (deep-imported from `dist/profiles-client.js`, added to the main-process bundle inline list), and the wdocker daemon's `get_agents_with_profile` calls moved behind the same client. Cargo.lock was regenerated with only the profiles tag change, dropping the unrelated itertools churn.

Note: the `@theweave/*` `0.7.0-dev.0 → dev.1` hunks in yarn.lock are stale-lockfile catch-up (those package.json versions were already dev.1 on the base branch), not part of this bump.
