### PR TITLE
refactor(renderer): one listApps authority for applet install/running/disabled (Phase 2c)

### DIFF
--- a/src/renderer/src/groups/applet-status.test.ts
+++ b/src/renderer/src/groups/applet-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { AppInfo, AppStatus } from '@holochain/client';
+import { appIdFromAppletHash } from '@theweave/utils';
+import { partitionAppletsByStatus } from './applet-status';
+
+const appletHash = (fill: number) => new Uint8Array(39).fill(fill);
+
+const appStatus = (status: AppStatus['type']): AppStatus =>
+  status === 'disabled' ? { type: 'disabled', value: { type: 'user' } } : { type: status };
+
+const app = (id: string, status: AppStatus['type']): AppInfo =>
+  ({
+    installed_app_id: id,
+    status: appStatus(status),
+  }) as AppInfo;
+
+describe('partitionAppletsByStatus', () => {
+  const running = appletHash(1);
+  const disabled = appletHash(2);
+  const notInstalled = appletHash(3);
+  const awaiting = appletHash(4);
+  const apps = [
+    app(appIdFromAppletHash(running), 'enabled'),
+    app(appIdFromAppletHash(disabled), 'disabled'),
+    app(appIdFromAppletHash(awaiting), 'awaiting_memproofs'),
+    app('group#some-group', 'enabled'),
+  ];
+
+  it('partitions joined applets by conductor status', () => {
+    const result = partitionAppletsByStatus([running, disabled, notInstalled, awaiting], apps);
+    expect(result.installed).toEqual([running, disabled, awaiting]);
+    expect(result.running).toEqual([running]);
+    expect(result.disabled).toEqual([disabled]);
+  });
+
+  it('treats a joined-but-uninstalled applet as absent everywhere', () => {
+    const result = partitionAppletsByStatus([notInstalled], apps);
+    expect(result).toEqual({ installed: [], running: [], disabled: [] });
+  });
+
+  it('is empty for no joined applets', () => {
+    expect(partitionAppletsByStatus([], apps)).toEqual({
+      installed: [],
+      running: [],
+      disabled: [],
+    });
+  });
+});

--- a/src/renderer/src/groups/applet-status.ts
+++ b/src/renderer/src/groups/applet-status.ts
@@ -1,0 +1,28 @@
+import type { AppInfo } from '@holochain/client';
+import type { AppletHash } from '@theweave/api';
+import { appIdFromAppletHash, isAppDisabled, isAppRunning } from '@theweave/utils';
+
+export interface AppletStatusPartition {
+  installed: AppletHash[];
+  running: AppletHash[];
+  disabled: AppletHash[];
+}
+
+/** Partitions the applets this agent has joined in the group DNA by their
+ * conductor install status. `installed` is a superset of `running` ∪
+ * `disabled`: an app awaiting membrane proofs is installed but neither. */
+export function partitionAppletsByStatus(
+  myApplets: AppletHash[],
+  installedApps: AppInfo[],
+): AppletStatusPartition {
+  const appsById = new Map(installedApps.map((app) => [app.installed_app_id, app]));
+  const partition: AppletStatusPartition = { installed: [], running: [], disabled: [] };
+  for (const applet of myApplets) {
+    const app = appsById.get(appIdFromAppletHash(applet));
+    if (!app) continue;
+    partition.installed.push(applet);
+    if (isAppRunning(app)) partition.running.push(applet);
+    else if (isAppDisabled(app)) partition.disabled.push(applet);
+  }
+  return partition;
+}

--- a/src/renderer/src/groups/group-store.ts
+++ b/src/renderer/src/groups/group-store.ts
@@ -5,10 +5,12 @@ import {
   Readable,
   Unsubscriber,
   Writable,
+  asyncDerived,
   asyncReadable,
   completed,
   derived,
   get,
+  joinAsync,
   joinMap,
   lazyLoad,
   lazyLoadAndPoll,
@@ -74,13 +76,8 @@ import {
   walDecodeContext,
 } from '@theweave/group-client';
 import { FoyerStore } from './foyer.js';
-import {
-  appIdFromAppletHash,
-  deriveToolCompatibilityId,
-  isAppDisabled,
-  isAppRunning,
-  toLowerCaseB64,
-} from '@theweave/utils';
+import { partitionAppletsByStatus } from './applet-status.js';
+import { appIdFromAppletHash, deriveToolCompatibilityId } from '@theweave/utils';
 import { decode, encode } from '@msgpack/msgpack';
 import {
   AssetsClient,
@@ -1446,15 +1443,12 @@ export class GroupStore {
    * in order to not re-enable those when enabling all applets again
    */
   async disableAllApplets(): Promise<Array<AppletHash>> {
+    // Refresh the conductor's app list so the pre-disable snapshot is current.
+    await this.mossStore.installedApps.reload();
     const installedApplets = await toPromise(this.allMyInstalledApplets);
-    const installedApps = await this.mossStore.adminWebsocket.listApps({});
-    const disabledAppIds = installedApps
-      .filter((app) => isAppDisabled(app))
-      .map((appInfo) => appInfo.installed_app_id);
+    const disabledApplets = await toPromise(this.allMyDisabledApplets);
 
-    const disabledAppletsIds = installedApplets
-      .filter((appletHash) => disabledAppIds.includes(appIdFromAppletHash(appletHash)))
-      .map((appletHash) => encodeHashToBase64(appletHash));
+    const disabledAppletsIds = disabledApplets.map((appletHash) => encodeHashToBase64(appletHash));
     // persist which applets have already been disabled
     this.mossStore.persistedStore.disabledGroupApplets.set(disabledAppletsIds, this.groupDnaHash);
 
@@ -1517,86 +1511,6 @@ export class GroupStore {
   // Currently unused
   // allGroupApplets = lazyLoadAndPoll(async () => this.groupClient.getGroupApplets(), APPLETS_POLLING_FREQUENCY);
 
-  allMyInstalledApplets = manualReloadStore(async () => {
-    const allMyApplets = await (async () => {
-      if (!this.constructed) {
-        return retryUntilResolved<Array<AppletHash>>(
-          () => this.groupClient.getMyJoinedAppletsHashes(),
-          200,
-          undefined,
-          false,
-        );
-      }
-      return this.groupClient.getMyJoinedAppletsHashes();
-    })();
-
-    const installedApps = await this.mossStore.adminWebsocket.listApps({});
-
-    const output = allMyApplets.filter((appletHash) =>
-      installedApps
-        .map((appInfo) => appInfo.installed_app_id)
-        .includes(`applet#${toLowerCaseB64(encodeHashToBase64(appletHash))}`),
-    );
-    return output;
-  });
-
-  allMyRunningApplets = manualReloadStore(async () => {
-    const allMyApplets = await (async () => {
-      if (!this.constructed) {
-        return retryUntilResolved<Array<AppletHash>>(
-          () => this.groupClient.getMyJoinedAppletsHashes(),
-          200,
-          undefined,
-          false,
-        );
-      }
-      return this.groupClient.getMyJoinedAppletsHashes();
-    })();
-    const installedApps = await this.mossStore.adminWebsocket.listApps({});
-    const runningAppIds = installedApps
-      .filter((app) => isAppRunning(app))
-      .map((appInfo) => appInfo.installed_app_id);
-
-    // console.log('Got runningAppIds: ', runningAppIds);
-    // console.log(
-    //   'Got allMyApplets: ',
-    //   allMyApplets.map((hash) => encodeHashToBase64(hash)),
-    // );
-
-    const output = allMyApplets.filter((appletHash) =>
-      runningAppIds.includes(`applet#${toLowerCaseB64(encodeHashToBase64(appletHash))}`),
-    );
-    // console.log(
-    //   'Got allMyRunningApplets: ',
-    //   output.map((h) => encodeHashToBase64(h)),
-    // );
-    return output;
-  });
-
-  // Applets I have joined and installed locally but which are currently disabled
-  // (installed in the conductor but not running).
-  allMyDisabledApplets = manualReloadStore(async () => {
-    const allMyApplets = await (async () => {
-      if (!this.constructed) {
-        return retryUntilResolved<Array<AppletHash>>(
-          () => this.groupClient.getMyJoinedAppletsHashes(),
-          200,
-          undefined,
-          false,
-        );
-      }
-      return this.groupClient.getMyJoinedAppletsHashes();
-    })();
-    const installedApps = await this.mossStore.adminWebsocket.listApps({});
-    const disabledAppIds = installedApps
-      .filter((app) => isAppDisabled(app))
-      .map((appInfo) => appInfo.installed_app_id);
-
-    return allMyApplets.filter((appletHash) =>
-      disabledAppIds.includes(`applet#${toLowerCaseB64(encodeHashToBase64(appletHash))}`),
-    );
-  });
-
   allMyApplets = manualReloadStore(async () => {
     if (!this.constructed) {
       return retryUntilResolved<Array<AppletHash>>(
@@ -1608,6 +1522,21 @@ export class GroupStore {
     }
     return this.groupClient.getMyJoinedAppletsHashes();
   });
+
+  // The applets this agent has joined in the group DNA, split by the status
+  // the conductor reports for them.
+  private myAppletsByStatus = asyncDerived(
+    joinAsync([this.allMyApplets, this.mossStore.installedApps]),
+    ([myApplets, installedApps]) => partitionAppletsByStatus(myApplets, installedApps),
+  );
+
+  allMyInstalledApplets = asyncDerived(this.myAppletsByStatus, (status) => status.installed);
+
+  allMyRunningApplets = asyncDerived(this.myAppletsByStatus, (status) => status.running);
+
+  // Applets I have joined and installed locally but which are currently disabled
+  // (installed in the conductor but not running).
+  allMyDisabledApplets = asyncDerived(this.myAppletsByStatus, (status) => status.disabled);
 
   allAdvertisedApplets = manualReloadStore(async () => {
     if (!this.constructed) {

--- a/src/renderer/src/moss-store.ts
+++ b/src/renderer/src/moss-store.ts
@@ -1480,7 +1480,7 @@ export class MossStore {
     await this.adminWebsocket.disableApp({
       installed_app_id: appIdFromAppletHash(appletHash),
     });
-    await this.reloadAfterAppletEnableDisable(appletHash);
+    await this.reloadAfterAppletEnableDisable();
   }
 
   async enableApplet(appletHash: EntryHash) {
@@ -1490,7 +1490,7 @@ export class MossStore {
     await this.adminWebsocket.enableApp({
       installed_app_id: appIdFromAppletHash(appletHash),
     });
-    await this.reloadAfterAppletEnableDisable(appletHash);
+    await this.reloadAfterAppletEnableDisable();
   }
 
   /**
@@ -1947,13 +1947,6 @@ export class MossStore {
     );
     await this.disabledGroups.reload();
     await this.groupStores.reload();
-    // const groupStores = await toPromise(this.groupStores);
-    // await Promise.all(
-    //   Array.from(groupStores.values()).map(async (store) => {
-    //     await store.allMyApplets.reload();
-    //     await store.allMyRunningApplets.reload();
-    //   }),
-    // );
     await this.installedApps.reload();
     await this.allAppAssetInfos.reload();
   }
@@ -1967,26 +1960,14 @@ export class MossStore {
     await this.installedApps.reload();
     await this.allAppAssetInfos.reload();
     await groupStore.allMyApplets.reload();
-    await groupStore.allMyInstalledApplets.reload();
-    await groupStore.allMyRunningApplets.reload();
   }
 
   /**
-   * Refresh the stores that go stale when an applet is enabled or disabled:
-   * the conductor's installed-app list and the running-applets store of every
-   * group containing this applet.
+   * Refresh the conductor's installed-app list, which is the authority the
+   * per-group applet status stores derive from.
    */
-  async reloadAfterAppletEnableDisable(appletHash: AppletHash) {
+  async reloadAfterAppletEnableDisable() {
     await this.installedApps.reload();
-    const groupStores = await toPromise(this.groupsForApplet.get(appletHash)!);
-    await Promise.all(
-      Array.from(groupStores.values()).map(async (gs) => {
-        if (gs) {
-          await gs.allMyRunningApplets.reload();
-          await gs.allMyDisabledApplets.reload();
-        }
-      }),
-    );
   }
 
   async emitParentToAppletMessage(message: ParentToAppletMessage, forApplets: AppletId[]) {


### PR DESCRIPTION
Part 3 of 4 of Phase 2 ("one authority per concept") from `plans/maintainability-assessment.md` §4.5/§7. Stacked on #238.

## What

- Adds `src/renderer/src/groups/applet-status.ts` — pure `partitionAppletsByStatus(myApplets, installedApps)` with table tests, preserving the invariant that `installed` is a superset of `running` ∪ `disabled` (an app awaiting membrane proofs is installed but neither).
- Replaces the three copy-pasted `manualReloadStore`s in `GroupStore` (`allMyInstalledApplets` / `allMyRunningApplets` / `allMyDisabledApplets`) — each of which did its own `adminWebsocket.listApps({})` round-trip and inline `` `applet#${…}` `` id construction — with derivations over `joinAsync([allMyApplets, mossStore.installedApps])`. The three members keep their names and `AsyncReadable<AppletHash[]>` shape, so none of their readers change.
- `disableAllApplets` reads the derived stores (after refreshing the parent) instead of doing its own `listApps`.
- Reload orchestration simplifies to two levers (`installedApps.reload()`, `allMyApplets.reload()`); propagation is automatic.

## Bugs this closes by construction

The old trio could hold three snapshots of the conductor taken at three different times:
- `reloadAfterAppletActivation` reloaded installed+running but never `allMyDisabledApplets`;
- `reloadAfterAppletEnableDisable` reloaded running+disabled but never `allMyInstalledApplets`.

Both asymmetries are gone — the three views now derive from one snapshot.

## Verification

- `grep "listApps({})" group-store.ts` → zero hits; no `.reload()` caller of the trio remains anywhere in src/.
- Class-field initialization order verified (parameter properties assign before field initializers under the renderer's tsconfig; `allMyApplets` hoisted above the derivation).
- `yarn typecheck` clean; `yarn test:unit` 164/164 at this point in the stack.
- Adversarially reviewed by an independent session: approved; the reviewer verified the store-primitive semantics (`manualReloadStore` reloads eagerly and does not reset to pending, so no UI flicker) and the freshness ordering in `disableAllApplets`.