### PR TITLE
fix(main): refresh the applet signing scope when an applet's clone cells change

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1565,6 +1565,12 @@ if (!RUNNING_WITH_COMMAND) {
         appletZomeCallAuthorizer.invalidate();
       },
     );
+    // Applet clone cells are created, enabled and disabled from the renderer over
+    // the applet's own app websocket, so the main process learns of them only
+    // through this call; the applet's next signing request must see the new cell.
+    ipcMain.handle('refresh-applet-signing-scope', (): void => {
+      appletZomeCallAuthorizer.invalidate();
+    });
     ipcMain.handle('is-dev-mode-enabled', (_e): boolean => !app.isPackaged || RUN_OPTIONS.dev);
     ipcMain.handle('is-applet-dev', (_e): boolean => !!RUN_OPTIONS.devInfo);
     // why: lets the renderer's tool-library override the default production

--- a/src/preload/admin.ts
+++ b/src/preload/admin.ts
@@ -40,6 +40,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('dialog-messagebox', options),
   installApp: (filePath: string, appId: string, networkSeed?: string) =>
     ipcRenderer.invoke('install-app', filePath, appId, networkSeed),
+  refreshAppletSigningScope: () => ipcRenderer.invoke('refresh-applet-signing-scope'),
   lairSetupRequired: () => ipcRenderer.invoke('lair-setup-required'),
   findLegacyProfiles: () => ipcRenderer.invoke('find-legacy-profiles'),
   getLairBinaryVersion: () => ipcRenderer.invoke('get-lair-binary-version'),

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -1,3 +1,4 @@
+import { withSigningScopeRefresh } from './signing-scope';
 import { get, toPromise } from '@holochain-open-dev/stores';
 import {
   type AssetInfo,
@@ -774,7 +775,10 @@ export async function handleAppletIframeMessage(
       if (groupStores.size === 0) throw new Error('No group store found.');
       // Install the clone in the group
       const [appletClient, _] = await mossStore.getAppClient(appIdFromAppletHash(appletHash));
-      const clonedCell = await appletClient.createCloneCell(message.req);
+      const clonedCell = await withSigningScopeRefresh(
+        () => appletClient.createCloneCell(message.req),
+        () => window.electronAPI.refreshAppletSigningScope(),
+      );
       // Register the clone in the group dna(s) if it's supposed to be public
       if (message.publicToGroupMembers) {
         await Promise.all(
@@ -799,7 +803,10 @@ export async function handleAppletIframeMessage(
       }
       const appletHash = source.appletHash;
       const [appletClient, _] = await mossStore.getAppClient(appIdFromAppletHash(appletHash));
-      const clonedCell = await appletClient.enableCloneCell(message.req);
+      const clonedCell = await withSigningScopeRefresh(
+        () => appletClient.enableCloneCell(message.req),
+        () => window.electronAPI.refreshAppletSigningScope(),
+      );
       return clonedCell;
     }
     case 'disable-clone-cell': {
@@ -810,7 +817,10 @@ export async function handleAppletIframeMessage(
       }
       const appletHash = source.appletHash;
       const [appletClient, _] = await mossStore.getAppClient(appIdFromAppletHash(appletHash));
-      return appletClient.disableCloneCell(message.req);
+      return withSigningScopeRefresh(
+        () => appletClient.disableCloneCell(message.req),
+        () => window.electronAPI.refreshAppletSigningScope(),
+      );
     }
     /**
      * Asset related messages

--- a/src/renderer/src/applets/signing-scope.test.ts
+++ b/src/renderer/src/applets/signing-scope.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { withSigningScopeRefresh } from './signing-scope';
+
+describe('withSigningScopeRefresh', () => {
+  it('refreshes the signing scope after the cell change and before returning', async () => {
+    const order: string[] = [];
+    const result = await withSigningScopeRefresh(
+      async () => {
+        order.push('op');
+        return 'cloned';
+      },
+      async () => {
+        order.push('refresh');
+      },
+    );
+    expect(result).toBe('cloned');
+    expect(order).toEqual(['op', 'refresh']);
+  });
+
+  it('waits for the refresh to finish before resolving', async () => {
+    let refreshed = false;
+    await withSigningScopeRefresh(
+      async () => undefined,
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            refreshed = true;
+            resolve();
+          }, 10),
+        ),
+    );
+    expect(refreshed).toBe(true);
+  });
+
+  it('does not refresh when the cell change fails, and passes the error on', async () => {
+    let refreshed = false;
+    await expect(
+      withSigningScopeRefresh(
+        async () => {
+          throw new Error('clone failed');
+        },
+        async () => {
+          refreshed = true;
+        },
+      ),
+    ).rejects.toThrow('clone failed');
+    expect(refreshed).toBe(false);
+  });
+});

--- a/src/renderer/src/applets/signing-scope.ts
+++ b/src/renderer/src/applets/signing-scope.ts
@@ -1,0 +1,15 @@
+/**
+ * Runs an operation that changes an applet's set of cells (creating, enabling
+ * or disabling a clone cell), then refreshes the main process's zome-call
+ * signing scope before handing the result back. An applet typically calls into
+ * a new clone cell straight away, and the signer only signs for cells it knows
+ * belong to the calling applet.
+ */
+export async function withSigningScopeRefresh<T>(
+  cellChange: () => Promise<T>,
+  refreshSigningScope: () => Promise<void>,
+): Promise<T> {
+  const result = await cellChange();
+  await refreshSigningScope();
+  return result;
+}

--- a/src/renderer/src/electron-api.ts
+++ b/src/renderer/src/electron-api.ts
@@ -68,6 +68,7 @@ declare global {
         kind: 'image' | 'iframe',
       ) => Promise<{ ok: true; contentType: string } | { ok: false; reason: string }>;
       installApp: (filePath: string, appId: string, networkSeed?: string) => Promise<void>;
+      refreshAppletSigningScope: () => Promise<void>;
       isAppletDev: () => Promise<boolean>;
       appletDevConfig: () => Promise<WeaveDevConfig | undefined>;
       getToolCurationOverride: () => Promise<string | undefined>;


### PR DESCRIPTION
An applet that creates a clone cell and calls into it straight away is refused with `Refusing to sign zome call ... unknown-cell`. Acorn hits it on every project create/join (`createCloneCell`, then `createWhoami` on the new cell), which blocks the acorn walk on the 0.16 line.

Clone cells are created, enabled and disabled in the renderer over the applet's own app websocket, and nothing told the main-process `AppletZomeCallAuthorizer`. Its unknown-cell rebuild is rate-limited to one per second and coalesces onto an in-flight rebuild, so the call can be checked against a listing taken before the clone existed.

- The renderer awaits a new `refresh-applet-signing-scope` IPC after creating, enabling or disabling an applet clone cell, before returning the result to the applet.
- The main process invalidates the authorizer there, as it already does for install, uninstall and enable.
- `withSigningScopeRefresh` carries the ordering, with unit tests written first.

`yarn test:unit` and `yarn typecheck:node` / `typecheck:web` pass.
