### PR TITLE
fix(tool-library): render a version's changelog as markdown

### DIFF
--- a/src/renderer/src/tool-library/elements/library-tool-details.ts
+++ b/src/renderer/src/tool-library/elements/library-tool-details.ts
@@ -77,7 +77,10 @@ export class LibraryToolDetails extends LitElement {
           <span>${this.timeAgo.format(version.releasedAt)}</span></sl-tooltip
         >
       </div>
-      <div>${msg(str`Change Log: ${version.changelog}`)}</div>
+      <div class="changelog">
+        <div>${msg('Change Log:')}</div>
+        ${unsafeHTML(markdownParseSafe(version.changelog ?? ''))}
+      </div>
       ${!this.informational && showInstallButton && hasMultipleBranches
         ? html`
             <select-group
@@ -330,6 +333,15 @@ export class LibraryToolDetails extends LitElement {
     mossStyles,
     libraryStyles,
     css`
+      .changelog p,
+      .changelog ul,
+      .changelog ol {
+        margin: 4px 0;
+      }
+      .changelog ul,
+      .changelog ol {
+        padding-left: 20px;
+      }
       .version-list {
         margin-top: 25px;
       }

--- a/src/renderer/xliff/de.xlf
+++ b/src/renderer/xliff/de.xlf
@@ -2272,9 +2272,9 @@ beginnt jetzt</target>
   <source>Released:</source>
   <target>Veröffentlicht:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Änderungsprotokoll: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Änderungsprotokoll:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/es.xlf
+++ b/src/renderer/xliff/es.xlf
@@ -2272,9 +2272,9 @@ comienza ahora</target>
   <source>Released:</source>
   <target>Publicado:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Registro de cambios: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Registro de cambios:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/fr.xlf
+++ b/src/renderer/xliff/fr.xlf
@@ -2272,9 +2272,9 @@ commence maintenant</target>
   <source>Released:</source>
   <target>Publié :</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Journal des modifications : <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Journal des modifications :</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/it.xlf
+++ b/src/renderer/xliff/it.xlf
@@ -2272,9 +2272,9 @@ inizia ora</target>
   <source>Released:</source>
   <target>Pubblicato:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Registro modifiche: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Registro modifiche:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/ja.xlf
+++ b/src/renderer/xliff/ja.xlf
@@ -2272,9 +2272,9 @@ starts now</source>
   <source>Released:</source>
   <target>公開日:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>変更履歴: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>変更履歴:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/nl.xlf
+++ b/src/renderer/xliff/nl.xlf
@@ -2272,9 +2272,9 @@ begint nu</target>
   <source>Released:</source>
   <target>Uitgebracht:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Wijzigingslogboek: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Wijzigingslogboek:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/pt.xlf
+++ b/src/renderer/xliff/pt.xlf
@@ -2272,9 +2272,9 @@ começa agora</target>
   <source>Released:</source>
   <target>Publicado:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Registro de alterações: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Registro de alterações:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>

--- a/src/renderer/xliff/tr.xlf
+++ b/src/renderer/xliff/tr.xlf
@@ -2272,9 +2272,9 @@ starts now</source>
   <source>Released:</source>
   <target>Yayınlandı:</target>
 </trans-unit>
-<trans-unit id="s0246d749f0d614a1">
-  <source>Change Log: <x id="0" equiv-text="${version.changelog}"/></source>
-  <target>Değişiklik günlüğü: <x id="0" equiv-text="${version.changelog}"/></target>
+<trans-unit id="s7c0d28da79593407">
+  <source>Change Log:</source>
+  <target>Değişiklik günlüğü:</target>
 </trans-unit>
 <trans-unit id="sa17c38293a901a5e">
   <source>No permission to edit group home.</source>


### PR DESCRIPTION
The Versions tab of the tool details showed the changelog as plain text inside the translated `Change Log: …` string, so a markdown changelog (lists, paragraphs) ran together on one line. It now renders through `markdownParseSafe` (marked + DOMPurify), the same path the Overview tab uses for the description, with `Change Log:` as its own translated label.

The eight xliff files carry the label over from the old string's translations, minus the placeholder; no other units change. Renderer component tests remain deferred for this element (no DOM environment in the unit suite; see its existing `TODO(test)`).

`yarn typecheck:web` and `yarn test:unit` pass.
